### PR TITLE
Restructure dotfiles into Loadout base layer

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,23 @@
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run validation
+        run: |
+          chmod +x test/validate.sh
+          ./test/validate.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+*.whl
+.venv/
+venv/
+env/
+
+# Shell
+*.swp
+*.swo
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# VS Code
+.vscode/
+*.code-workspace
+
+# Cursor
+.cursor/
+
+# JetBrains (PyCharm, WebStorm, IntelliJ, etc.)
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# iTerm2
+iterm2/DynamicProfiles/
+
+# Vim / Neovim
+*.swp
+*.swo
+*~
+.netrwhist
+tags
+
+# Environment / secrets (safety net)
+.env
+.env.*
+!.env.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,101 +1,77 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Repository Overview
 
-This is a **public dotfiles repository** containing configuration templates and base setups for macOS. It is part of a three-repository system:
-
-1. **`claude-personal-assistant`** - Public AIDE framework (core AI assistant system)
-2. **`dotfiles`** (this repo) - Public configuration templates
-3. **`dotfiles-private`** - Private configurations (not in this repo)
-
-The repository uses **GNU Stow** for symlink-based installation, allowing packages to be selectively installed and easily managed.
+**Loadout** — a layered macOS machine configuration system. This is the public base layer containing configuration templates, bootstrap scripts, and system defaults. No personal information, no org-specific content.
 
 ## Architecture
 
-### Stow Package System
+### Layer System
 
-The repository is organized as Stow packages - each subdirectory represents a package that can be independently installed:
+Loadout uses a three-layer merge model (only the base layer lives here):
 
-- **shell/** - Zsh configuration (`.zshrc` sources `.zshrc.local` for private configs)
-- **git/** - Git configuration template (`.gitconfig`, `.gitignore_global`)
-- **aide/** - AIDE configuration templates (`CLAUDE.md.template`, `.claude/` templates)
-- **scripts/** - Utility scripts in `bin/` subdirectory
-- **vim/** - Vim configuration (`.vimrc`)
+1. **Base** (this repo) — universal macOS defaults
+2. **Org** — team/company configs (separate repo)
+3. **Private** — personal identity and secrets (separate repo)
 
-**Critical Design Pattern**: Public configs use templates and source private overrides when available. The `.zshrc` sources `.zshrc.local` for private configurations that should never be committed to this public repo.
+Merge strategy: shell concatenation, gitconfig `[include]`, JSON deep merge via `jq`.
 
-### Installation Flow
+### Directory Layout
 
-1. User runs `stow <package>` from the repository root
-2. Stow creates symlinks from `~/<file>` → `~/dotfiles/<package>/<file>`
-3. Private configs from `dotfiles-private` can be stowed afterward to override public templates
+- **bootstrap/** — Installation scripts (`install-base.sh`, `install-user.sh`, `install-devbox.sh`)
+- **brewfiles/** — Homebrew bundle files (`Brewfile.base`, `Brewfile.devbox`)
+- **globals/** — Global runtime installers (`globals.base.sh`, `globals.devbox.sh`)
+- **dotfiles/base/** — Core dotfiles (`.zshrc`, `.gitconfig`, `.aliases`)
+- **dotfiles/devbox/** — Developer overlay (`50-devbox.zsh` for `~/.zshrc.d/`)
+- **claude/** — Claude Code config templates and MCP configs
+- **macos/** — System defaults scripts and power management
+- **iterm2/** — iTerm2 Dynamic Profile generator (Python, stdlib only)
+- **test/** — Validation script and CI workflow
+- **webapps/, slack/, canvas/** — Placeholder directories for future configs
+
+### Key Design Patterns
+
+- **Idempotent scripts** — all `.sh` files use `command -v` guards, check before acting
+- **No symlinks** — files are copied to `~/`; future `loadout build` merges layers
+- **Overlay hooks** — `~/.zshrc.local`, `~/.zshrc.d/*.zsh` (numeric prefix ordering), `~/.gitconfig.local`, `~/.gitconfig.d/`
+- **State directory** — `~/.loadout/` holds `backups/`, `logs/`, future `manifest.json`
+- **nvm via curl** (not Homebrew), **pyenv via Homebrew**, profile suppression with `PROFILE=/dev/null`
+- **1Password CLI** (`op`) for secrets, SSH via 1Password SSH agent
+- **pmset** for power management (not deprecated systemsetup)
 
 ## Common Commands
 
-### Package Management
-
 ```bash
-# Install all packages
-cd ~/dotfiles && stow */
+# Bootstrap a new machine
+./bootstrap/install-base.sh
+./bootstrap/install-user.sh
+./bootstrap/install-devbox.sh    # optional
 
-# Install specific package
-stow shell    # Install shell configs only
-stow git      # Install git config only
+# Run validation
+./test/validate.sh
 
-# Remove package
-stow -D vim   # Remove vim symlinks
-```
-
-### Development Workflow
-
-```bash
-# Edit configs (edits through symlinks back to repo)
-vim ~/.zshrc          # Edits ~/dotfiles/shell/.zshrc
-
-# Commit changes
-cd ~/dotfiles
-git add <package>/<file>
-git commit -m "Updated <package> config"
-git push
-```
-
-### New Machine Setup
-
-```bash
-# 1. Install prerequisites
-brew install stow git
-
-# 2. Clone and install dotfiles
-git clone <repo-url> ~/dotfiles
-cd ~/dotfiles && stow */
-
-# 3. Customize templates
-vim ~/.gitconfig  # Replace placeholders
+# Generate iTerm2 profile
+python3 iterm2/generate-profile.py --name "My Profile" --output ~/Library/Application\ Support/iTerm2/DynamicProfiles/profile.json
 ```
 
 ## Important Constraints
 
-### Public vs Private
+### Public Repository Rules
 
-**NEVER commit to this repository**:
+**NEVER commit**:
 - API keys, tokens, or secrets
 - Personal email addresses or identifiers
-- Machine-specific paths or configurations
-- Private aliases or workflows
+- Machine-specific paths (no `/Users/username/`)
+- Organization-specific configurations
 
-**Use `.zshrc.local` or `dotfiles-private` repo instead** for sensitive/private configurations.
+### Script Standards
 
-### Template Pattern
+- All `.sh` files must have `#!/usr/bin/env bash` shebang
+- All `.py` files must have `#!/usr/bin/env python3` shebang
+- All scripts must be executable (`chmod +x`)
+- All scripts must pass `shellcheck --severity=warning`
+- No `>>` appends without guards, no `mkdir` without `-p`
 
-Files ending in `.template` are meant to be copied and customized:
-- `CLAUDE.md.template` → copy to `~/CLAUDE.md` and customize
-- `.claude/knowledge/*.template` → populate with personal information
+### Testing
 
-### Stow Requirements
-
-When creating new packages:
-- Files must be inside a package directory (e.g., `newpackage/.config/tool/config`)
-- Stow will recreate the directory structure from the package folder to `~/`
-- Ensure no conflicts with existing files before stowing
+`test/validate.sh` runs 10 checks — shellcheck, JSON/plist validation, secrets scan, path scan, idempotency checks. CI runs on every push/PR via `.github/workflows/validate.yml`.

--- a/README.md
+++ b/README.md
@@ -1,255 +1,92 @@
-# My Dotfiles
+# Loadout
 
-Personal configuration files and templates for macOS, featuring AIDE integration (Claude personal assistant system).
+A layered macOS machine configuration system. This is the **public base layer** — no personal information, no organization-specific content.
 
 ## Overview
 
-**This is my PUBLIC DOTFILES repository** - configuration templates and base setups that others can learn from and adapt.
+Loadout replaces traditional symlink-based dotfiles with a **layered merge system**:
 
-### The Three-Repo System
+- **Base layer** (this repo) — sensible defaults for any macOS machine
+- **Org layer** — team/company tools, standards, and configs
+- **Private layer** — personal identity, secrets, API keys
 
-This is part of my complete development environment:
+Each layer extends and overrides the one below it. Shell configs concatenate, gitconfigs use `[include]`, JSON merges deeply via `jq`.
 
-1. **`claude-personal-assistant`** - Public AIDE framework
-    - Core system that powers my AI assistant
-    - [github.com/you/claude-personal-assistant](https://github.com/you/claude-personal-assistant)
+## Quick Start
 
-2. **`dotfiles`** (this repo) - Public configuration templates
-    - Base shell configs, git setup, AIDE templates
-    - Generic scripts and workflows
-    - Safe to share publicly
+```bash
+# 1. Clone
+git clone https://github.com/oakensoul/dotfiles.git ~/dotfiles
+cd ~/dotfiles
 
-3. **`dotfiles-private`** - Private configurations
-    - My actual secrets and personal configs
-    - Overrides these templates
-    - Not publicly accessible
+# 2. Bootstrap base tools (Xcode CLI, Homebrew, core packages)
+./bootstrap/install-base.sh
 
-## Philosophy
+# 3. Install base dotfiles
+./bootstrap/install-user.sh
 
-These dotfiles serve as a **base layer** that can be extended with private configurations. Public configs use templates and source private overrides when available.
-
-Managed with **GNU Stow** for clean, organized, symlink-based installation.
+# 4. (Optional) Install dev tools
+./bootstrap/install-devbox.sh
+```
 
 ## Structure
 
 ```
 dotfiles/
-├── shell/
-│   └── .zshrc              # Sources .zshrc.local for private configs
-├── git/
-│   └── .gitconfig          # Template with placeholders
-├── aide/
-│   ├── CLAUDE.md.template  # AIDE configuration template
-│   └── .claude/
-│       └── knowledge/
-│           └── *.template  # Knowledge base templates
-├── scripts/
-│   └── bin/
-│       └── *.sh           # Useful utility scripts
-└── vim/
-    └── .vimrc             # Vim configuration
+├── bootstrap/          # Installation scripts (base, user, devbox)
+├── brewfiles/          # Homebrew bundle files
+├── globals/            # Global language runtimes and tools
+├── dotfiles/           # Shell, git, and alias configs
+│   ├── base/           # Core dotfiles for any machine
+│   └── devbox/         # Developer overlay (zshrc.d drop-in)
+├── claude/             # Claude Code configuration templates
+├── macos/              # macOS system defaults and power management
+├── iterm2/             # iTerm2 profile generation
+├── test/               # Validation and CI
+├── webapps/            # Web app configs (placeholder)
+├── slack/              # Slack configs (placeholder)
+└── canvas/             # Canvas configs (placeholder)
 ```
 
-## Quick Start
+## Design Principles
 
-```bash
-# Clone this repo
-git clone https://github.com/you/dotfiles.git ~/dotfiles
+- **Idempotent** — every script checks before acting, safe to re-run
+- **No symlinks** — files are copied; future `loadout build` will merge layers
+- **Overlay hooks** — `~/.zshrc.local`, `~/.zshrc.d/*.zsh`, `~/.gitconfig.local`, `~/.gitconfig.d/`
+- **1Password CLI** (`op`) for secrets management and SSH agent
+- **No personal data** — this repo contains zero identity information
 
-# Install with Stow
-cd ~/dotfiles
-stow */
-
-# Customize the templates
-vim ~/.gitconfig  # Add your name/email
-vim ~/CLAUDE.md   # Configure AIDE
-
-# Create private overrides
-echo "export API_KEY=secret" > ~/.zshrc.local
-```
-
-## Installation
-
-### Prerequisites
-
-```bash
-# Install Stow
-brew install stow
-
-# Install AIDE framework
-git clone https://github.com/you/claude-personal-assistant.git ~/.aide
-cd ~/.aide && ./install.sh
-```
-
-### Install All Packages
-
-```bash
-cd ~/dotfiles
-stow */
-```
-
-### Install Specific Packages
-
-```bash
-cd ~/dotfiles
-stow shell    # Install shell configs
-stow git      # Install git config
-stow aide     # Install AIDE templates
-stow scripts  # Install utility scripts
-```
-
-## Packages
+## Overlay System
 
 ### Shell
-- `.zshrc` - Zsh configuration
-- Sources `.zshrc.local` for private configurations
-- Generic aliases and PATH setup
+- `~/.zshrc` — base shell config
+- `~/.zshrc.d/*.zsh` — numbered drop-ins (10-* org, 50-* devbox, 90-* private)
+- `~/.zshrc.local` — final private overrides (sourced last)
 
 ### Git
-- `.gitconfig` - Git configuration template
-- `.gitignore_global` - Global gitignore patterns
-- Replace placeholders with your information
+- `~/.gitconfig` — base git config (no `[user]` section)
+- `~/.gitconfig.d/` — include directory for org/team configs
+- `~/.gitconfig.local` — private identity and overrides
 
-### AIDE
-- `CLAUDE.md.template` - AIDE configuration template
-- `.claude/` templates - Knowledge base structure
-- Integrates with [claude-personal-assistant](https://github.com/you/claude-personal-assistant)
+### State Directory
+- `~/.loadout/` — managed state: `backups/`, `logs/`, future `manifest.json`
 
-### Scripts
-- `bin/` - Utility scripts
-- Generic helpers and tools
-- Nothing machine-specific
+## Bootstrap Scripts
 
-### Vim
-- `.vimrc` - Vim configuration
-- Basic setup, extend as needed
+| Script | What it does |
+|--------|-------------|
+| `install-base.sh` | Xcode CLI tools, Homebrew, Brewfile.base, global runtimes, macOS defaults |
+| `install-user.sh` | Back up existing dotfiles, copy base configs to `~/`, create `~/.loadout/` |
+| `install-devbox.sh` | Brewfile.devbox, dev runtimes, devbox shell overlay, display detection |
 
-## Customization
-
-### Private Overrides
-
-Create a `~/.zshrc.local` file for private configurations:
+## Validation
 
 ```bash
-# ~/.zshrc.local
-export ANTHROPIC_API_KEY="your-key"
-export WORK_EMAIL="you@company.com"
-
-alias work='cd ~/Development/work'
+./test/validate.sh
 ```
 
-This file is sourced by `.zshrc` but never committed.
-
-### AIDE Setup
-
-1. Install AIDE framework: `cd ~/.aide && ./install.sh`
-2. Copy template: `cp ~/CLAUDE.md.template ~/CLAUDE.md`
-3. Customize `~/CLAUDE.md` with your preferences
-4. Populate `~/.claude/knowledge/` with your information
-
-### Extending with Private Repo
-
-Create a `dotfiles-private` repository that stows on top:
-
-```bash
-# Stow public first
-cd ~/dotfiles && stow */
-
-# Stow private second (overrides public)
-cd ~/dotfiles-private && stow */
-```
-
-## Usage
-
-### Update Configs
-
-```bash
-# Edit through symlinks
-vim ~/.zshrc          # Edits ~/dotfiles/shell/.zshrc
-
-# Commit changes
-cd ~/dotfiles
-git add shell/.zshrc
-git commit -m "Updated shell config"
-git push
-```
-
-### Add New Package
-
-```bash
-cd ~/dotfiles
-mkdir newpackage
-# Add files to newpackage/
-stow newpackage
-git add newpackage/
-git commit -m "Added new package"
-```
-
-### Remove Package
-
-```bash
-cd ~/dotfiles
-stow -D vim    # Remove symlinks
-rm -rf vim/    # Remove package
-```
-
-## New Machine Setup
-
-```bash
-# 1. Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# 2. Install Stow
-brew install stow git
-
-# 3. Clone dotfiles
-git clone https://github.com/you/dotfiles.git ~/dotfiles
-
-# 4. Stow everything
-cd ~/dotfiles && stow */
-
-# 5. Install AIDE
-git clone https://github.com/you/claude-personal-assistant.git ~/.aide
-cd ~/.aide && ./install.sh
-
-# 6. Customize
-vim ~/.gitconfig  # Add your info
-vim ~/CLAUDE.md   # Configure AIDE
-```
-
-## AIDE Integration
-
-This dotfiles repo includes templates for AIDE (Claude personal assistant):
-
-- `aide/CLAUDE.md.template` - Main configuration template
-- `aide/.claude/` - Knowledge base structure
-- Integrates with the [claude-personal-assistant](https://github.com/you/claude-personal-assistant) framework
-
-After stowing, install AIDE and customize the templates.
-
-## Requirements
-
-- macOS (adaptable to Linux)
-- GNU Stow
-- Git
-- Zsh (or adapt to Bash)
+Runs shellcheck, JSON/plist validation, secrets scanning, and portability checks. Also runs in CI on every push and PR.
 
 ## License
 
-MIT License - Feel free to use and adapt!
-
-## Inspiration
-
-- [mathiasbynens/dotfiles](https://github.com/mathiasbynens/dotfiles)
-- [holman/dotfiles](https://github.com/holman/dotfiles)
-- [paulirish/dotfiles](https://github.com/paulirish/dotfiles)
-
-## Links
-
-- AIDE Framework: [claude-personal-assistant](https://github.com/you/claude-personal-assistant)
-- My Blog: [your-blog.com](https://your-blog.com)
-- Twitter: [@yourusername](https://twitter.com/yourusername)
-
----
-
-**These are templates - customize for your own use!**
+AGPL-3.0 — see [LICENSE](LICENSE) for details.

--- a/bootstrap/install-base.sh
+++ b/bootstrap/install-base.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# install-base.sh — Bootstrap base tools on a fresh macOS machine
+# Installs: Xcode CLI tools, Homebrew, Brewfile.base, global runtimes, macOS defaults
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+skip()  { printf '\033[1;33m[SKIP]\033[0m  %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Xcode Command Line Tools
+# ---------------------------------------------------------------------------
+if xcode-select -p >/dev/null 2>&1; then
+    skip "Xcode CLI tools already installed"
+else
+    info "Installing Xcode Command Line Tools..."
+    xcode-select --install
+    info "Waiting for Xcode CLI tools installation to complete..."
+    until xcode-select -p >/dev/null 2>&1; do
+        sleep 5
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Homebrew
+# ---------------------------------------------------------------------------
+if command -v brew >/dev/null 2>&1; then
+    skip "Homebrew already installed"
+else
+    info "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Load Homebrew into current session
+    if [[ -d /opt/homebrew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -d /usr/local/Homebrew ]]; then
+        eval "$(/usr/local/Homebrew/bin/brew shellenv)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Brewfile.base
+# ---------------------------------------------------------------------------
+info "Installing base packages from Brewfile.base..."
+brew bundle --file="$REPO_ROOT/brewfiles/Brewfile.base" --no-lock
+
+# Brewfile.local (user extension hook)
+if [[ -f "$REPO_ROOT/brewfiles/Brewfile.local" ]]; then
+    info "Installing packages from Brewfile.local..."
+    brew bundle --file="$REPO_ROOT/brewfiles/Brewfile.local" --no-lock
+fi
+
+# ---------------------------------------------------------------------------
+# Global runtimes
+# ---------------------------------------------------------------------------
+info "Installing global runtimes..."
+source "$REPO_ROOT/globals/globals.base.sh"
+
+# ---------------------------------------------------------------------------
+# macOS defaults
+# ---------------------------------------------------------------------------
+info "Applying macOS base defaults..."
+source "$REPO_ROOT/macos/defaults-base.sh"
+
+info "install-base.sh complete. Restart your terminal for all changes to take effect."

--- a/bootstrap/install-devbox.sh
+++ b/bootstrap/install-devbox.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# install-devbox.sh — Install developer tools and overlay
+# Requires: install-base.sh has been run (Homebrew available)
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+skip()  { printf '\033[1;33m[SKIP]\033[0m  %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Preflight: Homebrew must be available
+# ---------------------------------------------------------------------------
+if ! command -v brew >/dev/null 2>&1; then
+    printf '\033[1;31m[ERROR]\033[0m Homebrew not found. Run install-base.sh first.\n' >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Brewfile.devbox
+# ---------------------------------------------------------------------------
+info "Installing devbox packages from Brewfile.devbox..."
+brew bundle --file="$REPO_ROOT/brewfiles/Brewfile.devbox" --no-lock
+
+# Brewfile.local (user extension hook)
+if [[ -f "$REPO_ROOT/brewfiles/Brewfile.local" ]]; then
+    info "Installing packages from Brewfile.local..."
+    brew bundle --file="$REPO_ROOT/brewfiles/Brewfile.local" --no-lock
+fi
+
+# ---------------------------------------------------------------------------
+# Global dev packages
+# ---------------------------------------------------------------------------
+info "Installing global dev packages..."
+source "$REPO_ROOT/globals/globals.devbox.sh"
+
+# ---------------------------------------------------------------------------
+# Devbox shell overlay
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.zshrc.d"
+cp "$REPO_ROOT/dotfiles/devbox/50-devbox.zsh" "$HOME/.zshrc.d/50-devbox.zsh"
+info "Installed ~/.zshrc.d/50-devbox.zsh"
+
+# ---------------------------------------------------------------------------
+# Display detection (apply once)
+# ---------------------------------------------------------------------------
+if [[ "$(uname)" == "Darwin" ]]; then
+    info "Detecting display configuration..."
+    source "$REPO_ROOT/macos/display-watch.sh" --apply-once
+fi
+
+info "install-devbox.sh complete. Restart your terminal for all changes to take effect."

--- a/bootstrap/install-user.sh
+++ b/bootstrap/install-user.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# install-user.sh — Install base dotfiles to ~/
+# Creates ~/.loadout/, backs up existing files, copies base configs
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+skip()  { printf '\033[1;33m[SKIP]\033[0m  %s\n' "$1"; }
+warn()  { printf '\033[1;33m[WARN]\033[0m  %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Create ~/.loadout/ state directory
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.loadout/backups"
+mkdir -p "$HOME/.loadout/logs"
+info "State directory: ~/.loadout/"
+
+# ---------------------------------------------------------------------------
+# Backup existing dotfiles
+# ---------------------------------------------------------------------------
+BACKUP_DIR="$HOME/.loadout/backups/$(date +%Y-%m-%d-%H%M%S)"
+files_to_install=(
+    ".zshrc"
+    ".gitconfig"
+    ".aliases"
+)
+needs_backup=false
+for f in "${files_to_install[@]}"; do
+    if [[ -f "$HOME/$f" ]]; then
+        needs_backup=true
+        break
+    fi
+done
+
+if [[ "$needs_backup" == true ]]; then
+    mkdir -p "$BACKUP_DIR"
+    info "Backing up existing dotfiles to $BACKUP_DIR/"
+    for f in "${files_to_install[@]}"; do
+        if [[ -f "$HOME/$f" ]]; then
+            cp "$HOME/$f" "$BACKUP_DIR/$f"
+            info "  Backed up ~/$f"
+        fi
+    done
+else
+    skip "No existing dotfiles to back up"
+fi
+
+# ---------------------------------------------------------------------------
+# Copy base dotfiles
+# ---------------------------------------------------------------------------
+info "Installing base dotfiles..."
+for f in "${files_to_install[@]}"; do
+    cp "$REPO_ROOT/dotfiles/base/$f" "$HOME/$f"
+    info "  Installed ~/$f"
+done
+
+# ---------------------------------------------------------------------------
+# Create overlay directories
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.zshrc.d"
+mkdir -p "$HOME/.gitconfig.d"
+info "Created overlay directories: ~/.zshrc.d/, ~/.gitconfig.d/"
+
+# ---------------------------------------------------------------------------
+# Set zsh as default shell
+# ---------------------------------------------------------------------------
+if [[ "$SHELL" == */zsh ]]; then
+    skip "zsh is already the default shell"
+else
+    info "Setting zsh as default shell..."
+    chsh -s "$(command -v zsh)"
+fi
+
+# ---------------------------------------------------------------------------
+# Reminder
+# ---------------------------------------------------------------------------
+echo ""
+info "Base dotfiles installed. Next steps:"
+info "  1. Create ~/.gitconfig.local with your [user] section:"
+info "     git config --file ~/.gitconfig.local user.name \"Your Name\""
+info "     git config --file ~/.gitconfig.local user.email \"your@email.com\""
+info "  2. Source your new shell: source ~/.zshrc"
+info "  3. (Optional) Run install-devbox.sh for developer tools"

--- a/brewfiles/Brewfile.base
+++ b/brewfiles/Brewfile.base
@@ -1,0 +1,21 @@
+# Brewfile.base — Core tools for any macOS machine
+# Managed by Loadout
+
+# Terminal tools
+brew "git"
+brew "curl"
+brew "jq"
+brew "ripgrep"
+brew "fd"
+brew "fzf"
+brew "bat"
+brew "eza"
+brew "zoxide"
+
+# Security
+cask "1password-cli"
+
+# Desktop apps
+cask "iterm2"
+cask "rectangle"
+cask "raycast"

--- a/brewfiles/Brewfile.devbox
+++ b/brewfiles/Brewfile.devbox
@@ -1,0 +1,17 @@
+# Brewfile.devbox — Developer tools
+# Managed by Loadout
+
+# Development CLI
+brew "gh"
+brew "lazygit"
+brew "shellcheck"
+brew "shfmt"
+
+# Python
+brew "pyenv"
+
+# Containers
+cask "docker"
+
+# Editor
+cask "visual-studio-code"

--- a/canvas/README.md
+++ b/canvas/README.md
@@ -1,0 +1,3 @@
+# Canvas
+
+Placeholder for Canvas configurations managed by Loadout.

--- a/claude/CLAUDE.md.template
+++ b/claude/CLAUDE.md.template
@@ -1,0 +1,35 @@
+# CLAUDE.md — User Configuration Template
+
+This is a template for your personal `~/CLAUDE.md` file. Copy it to your home directory and customize.
+
+## Identity
+
+<!-- Replace with your information -->
+- Name: YOUR_NAME
+- Role: YOUR_ROLE
+- GitHub: YOUR_GITHUB_USERNAME
+
+## Preferences
+
+<!-- Customize these for your workflow -->
+- Preferred language: English
+- Code style: Follow project conventions
+- Commit messages: Conventional commits
+- Communication style: Concise, direct
+
+## Tools
+
+<!-- List tools and services you use -->
+- Editor: VS Code / Vim
+- Terminal: iTerm2
+- Password manager: 1Password (CLI: `op`)
+
+## MCP Servers
+
+MCP configuration files are located at:
+- `~/.claude/mcp-shared.json` — shared across all projects
+- `~/.claude/mcp-devbox.json` — developer-specific servers
+
+## Notes
+
+<!-- Add any personal notes or context for Claude -->

--- a/claude/base/mcp-shared.json
+++ b/claude/base/mcp-shared.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/claude/devbox/mcp-devbox.json
+++ b/claude/devbox/mcp-devbox.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -3,7 +3,7 @@
 # statusline.sh — Claude Code custom status line
 #
 # Reads JSON from stdin, outputs a formatted single-line status.
-# Format: repo | branch | S:n U:n ?:n | model | ctx: N% | $X.XX
+# Format: repo | user | branch | S:n U:n ?:n | model | ctx: N% | $X.XX
 #
 # Requires: jq (installed via brew if missing)
 #
@@ -28,6 +28,7 @@ GREEN='\033[32m'
 YELLOW='\033[33m'
 RED='\033[31m'
 WHITE='\033[37m'
+MAGENTA='\033[35m'
 RESET='\033[0m'
 
 # ---------------------------------------------------------------------------
@@ -37,6 +38,7 @@ RESET='\033[0m'
 cwd="$(echo "$json" | jq -r '.cwd // .workspace.current_dir // empty' 2>/dev/null)"
 
 repo_name=""
+git_username=""
 branch=""
 staged=0
 unstaged=0
@@ -48,6 +50,7 @@ if [[ -n "$cwd" ]] && [[ -d "$cwd" ]]; then
     if [[ -n "$repo_root" ]]; then
         repo_name="$(basename "$repo_root")"
         branch="$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)"
+        git_username="$(git -C "$cwd" config user.username 2>/dev/null)"
 
         # Staged count
         staged="$(git -C "$cwd" diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')"
@@ -123,6 +126,11 @@ parts=()
 
 # Repo name — cyan
 parts+=("${CYAN}${repo_name}${RESET}")
+
+# GitHub username — magenta (omit if not set)
+if [[ -n "$git_username" ]]; then
+    parts+=("${MAGENTA}${git_username}${RESET}")
+fi
 
 # Branch — green (only if in a git repo)
 if [[ -n "$branch" ]]; then

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -72,8 +72,14 @@ aida_status=""
 project_dir="$(echo "$json" | jq -r '.workspace.project_dir // empty' 2>/dev/null)"
 # Try project_dir first, fall back to git root, fall back to cwd
 aida_check_dir="${project_dir:-${repo_root:-$cwd}}"
-if [[ -n "$aida_check_dir" ]] && [[ -f "$aida_check_dir/.claude/aida-project-context.yml" ]]; then
-    aida_status="${GREEN}aida \xe2\x9c\x93${RESET}"
+aida_config="$aida_check_dir/.claude/aida-project-context.yml"
+if [[ -n "$aida_check_dir" ]] && [[ -f "$aida_config" ]]; then
+    aida_ver="$(grep -m1 '^version:' "$aida_config" 2>/dev/null | sed 's/^version:[[:space:]]*//' | tr -d "\"'")"
+    if [[ -n "$aida_ver" ]]; then
+        aida_status="${GREEN}aida \xe2\x9c\x93 ${aida_ver}${RESET}"
+    else
+        aida_status="${GREEN}aida \xe2\x9c\x93${RESET}"
+    fi
 else
     aida_status="${RED}aida \xe2\x9c\x97${RESET}"
 fi

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# statusline.sh — Claude Code custom status line
+#
+# Reads JSON from stdin, outputs a formatted single-line status.
+# Format: repo | branch | S:n U:n ?:n | model | ctx: N% | $X.XX
+#
+# Requires: jq (installed via brew if missing)
+#
+
+# Ensure jq is available
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq not found"
+    exit 0
+fi
+
+# Read JSON from stdin
+json="$(cat)"
+if [[ -z "$json" ]]; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Colors (ANSI)
+# ---------------------------------------------------------------------------
+CYAN='\033[36m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+WHITE='\033[37m'
+RESET='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Git: repo name and branch
+# ---------------------------------------------------------------------------
+# Get working directory from JSON (try both real and mock field paths)
+cwd="$(echo "$json" | jq -r '.cwd // .workspace.current_dir // empty' 2>/dev/null)"
+
+repo_name=""
+branch=""
+staged=0
+unstaged=0
+untracked=0
+
+if [[ -n "$cwd" ]] && [[ -d "$cwd" ]]; then
+    # Repo name: top-level dir basename, or cwd basename if not a repo
+    repo_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
+    if [[ -n "$repo_root" ]]; then
+        repo_name="$(basename "$repo_root")"
+        branch="$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)"
+
+        # Staged count
+        staged="$(git -C "$cwd" diff --cached --numstat 2>/dev/null | wc -l | tr -d ' ')"
+        # Unstaged count (tracked files only)
+        unstaged="$(git -C "$cwd" diff --numstat 2>/dev/null | wc -l | tr -d ' ')"
+        # Untracked count
+        untracked="$(git -C "$cwd" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
+    else
+        repo_name="$(basename "$cwd")"
+    fi
+else
+    repo_name="unknown"
+fi
+
+# ---------------------------------------------------------------------------
+# Model: shorten display name
+# ---------------------------------------------------------------------------
+model_display="$(echo "$json" | jq -r '.model.display_name // empty' 2>/dev/null)"
+model_id="$(echo "$json" | jq -r '.model.id // empty' 2>/dev/null)"
+
+# Shorten model: prefer id-based mapping, fall back to display name
+model=""
+case "$model_id" in
+    *opus-4-6*)     model="opus-4.6" ;;
+    *opus-4-5*)     model="opus-4.5" ;;
+    *opus*)         model="opus" ;;
+    *sonnet-4-6*)   model="sonnet-4.6" ;;
+    *sonnet-4-5*)   model="sonnet-4.5" ;;
+    *sonnet-4*)     model="sonnet-4" ;;
+    *haiku-4-5*)    model="haiku-4.5" ;;
+    *haiku*)        model="haiku" ;;
+    *)
+        # Fall back to display_name-based matching
+        case "$model_display" in
+            *opus*4.6*|*Opus*4.6*)     model="opus-4.6" ;;
+            *opus*4.5*|*Opus*4.5*)     model="opus-4.5" ;;
+            *[Oo]pus*)                 model="opus" ;;
+            *sonnet*4.6*|*Sonnet*4.6*) model="sonnet-4.6" ;;
+            *sonnet*4.5*|*Sonnet*4.5*) model="sonnet-4.5" ;;
+            *sonnet*4*|*Sonnet*4*)     model="sonnet-4" ;;
+            *haiku*4.5*|*Haiku*4.5*)   model="haiku-4.5" ;;
+            *[Hh]aiku*)                model="haiku" ;;
+            "")                        model="—" ;;
+            *)                         model="$model_display" ;;
+        esac
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Context window % used
+# ---------------------------------------------------------------------------
+ctx_pct="$(echo "$json" | jq -r '.context_window.used_percentage // empty' 2>/dev/null)"
+ctx_pct="${ctx_pct:-0}"
+
+if (( ctx_pct > 70 )); then
+    ctx_color="$RED"
+elif (( ctx_pct > 40 )); then
+    ctx_color="$YELLOW"
+else
+    ctx_color="$GREEN"
+fi
+
+# ---------------------------------------------------------------------------
+# Session cost
+# ---------------------------------------------------------------------------
+cost="$(echo "$json" | jq -r '.cost.total_cost_usd // .cost_usd.session // 0' 2>/dev/null)"
+cost_fmt="$(printf '%.2f' "${cost:-0}")"
+
+# ---------------------------------------------------------------------------
+# Assemble output
+# ---------------------------------------------------------------------------
+parts=()
+
+# Repo name — cyan
+parts+=("${CYAN}${repo_name}${RESET}")
+
+# Branch — green (only if in a git repo)
+if [[ -n "$branch" ]]; then
+    parts+=("${GREEN}${branch}${RESET}")
+fi
+
+# Git status counts — yellow, only non-zero
+git_counts=""
+[[ "$staged" -gt 0 ]]    && git_counts+="S:${staged} "
+[[ "$unstaged" -gt 0 ]]  && git_counts+="U:${unstaged} "
+[[ "$untracked" -gt 0 ]] && git_counts+="?:${untracked} "
+git_counts="${git_counts% }"
+if [[ -n "$git_counts" ]]; then
+    parts+=("${YELLOW}${git_counts}${RESET}")
+fi
+
+# Model — white
+parts+=("${WHITE}${model}${RESET}")
+
+# Context — color coded
+parts+=("${ctx_color}ctx: ${ctx_pct}%${RESET}")
+
+# Cost — white
+parts+=("${WHITE}\$${cost_fmt}${RESET}")
+
+# Join with " | "
+output=""
+for i in "${!parts[@]}"; do
+    if [[ "$i" -gt 0 ]]; then
+        output+=" | "
+    fi
+    output+="${parts[$i]}"
+done
+
+printf '%b\n' "$output"

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -73,10 +73,21 @@ project_dir="$(echo "$json" | jq -r '.workspace.project_dir // empty' 2>/dev/nul
 # Try project_dir first, fall back to git root, fall back to cwd
 aida_check_dir="${project_dir:-${repo_root:-$cwd}}"
 aida_config="$aida_check_dir/.claude/aida-project-context.yml"
+aida_marketplace="$HOME/.claude/plugins/marketplaces/aida/.claude-plugin/marketplace.json"
 if [[ -n "$aida_check_dir" ]] && [[ -f "$aida_config" ]]; then
     aida_ver="$(grep -m1 '^version:' "$aida_config" 2>/dev/null | sed 's/^version:[[:space:]]*//' | tr -d "\"'")"
+    # Get installed plugin version for comparison
+    aida_installed=""
+    if [[ -f "$aida_marketplace" ]]; then
+        aida_installed="$(jq -r '.plugins[] | select(.name=="aida-core") | .version // empty' "$aida_marketplace" 2>/dev/null)"
+    fi
     if [[ -n "$aida_ver" ]]; then
-        aida_status="${GREEN}aida \xe2\x9c\x93 ${aida_ver}${RESET}"
+        if [[ -n "$aida_installed" ]] && [[ "$aida_ver" != "$aida_installed" ]]; then
+            # Version mismatch — yellow with installed version hint
+            aida_status="${YELLOW}aida \xe2\x9a\xa0 ${aida_ver} \xe2\x86\x92 ${aida_installed}${RESET}"
+        else
+            aida_status="${GREEN}aida \xe2\x9c\x93 ${aida_ver}${RESET}"
+        fi
     else
         aida_status="${GREEN}aida \xe2\x9c\x93${RESET}"
     fi

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -3,7 +3,7 @@
 # statusline.sh — Claude Code custom status line
 #
 # Reads JSON from stdin, outputs a formatted single-line status.
-# Format: repo | user | branch | S:n U:n ?:n | model | ctx: N% | $X.XX
+# Format: repo | user | branch | S:n U:n ?:n | aida | model | ctx: N% | $X.XX
 #
 # Requires: jq (installed via brew if missing)
 #
@@ -63,6 +63,19 @@ if [[ -n "$cwd" ]] && [[ -d "$cwd" ]]; then
     fi
 else
     repo_name="unknown"
+fi
+
+# ---------------------------------------------------------------------------
+# AIDA: check for project configuration
+# ---------------------------------------------------------------------------
+aida_status=""
+project_dir="$(echo "$json" | jq -r '.workspace.project_dir // empty' 2>/dev/null)"
+# Try project_dir first, fall back to git root, fall back to cwd
+aida_check_dir="${project_dir:-${repo_root:-$cwd}}"
+if [[ -n "$aida_check_dir" ]] && [[ -f "$aida_check_dir/.claude/aida-project-context.yml" ]]; then
+    aida_status="${GREEN}aida \xe2\x9c\x93${RESET}"
+else
+    aida_status="${RED}aida \xe2\x9c\x97${RESET}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -146,6 +159,9 @@ git_counts="${git_counts% }"
 if [[ -n "$git_counts" ]]; then
     parts+=("${YELLOW}${git_counts}${RESET}")
 fi
+
+# AIDA status
+parts+=("$aida_status")
 
 # Model — white
 parts+=("${WHITE}${model}${RESET}")

--- a/dotfiles/base/.aliases
+++ b/dotfiles/base/.aliases
@@ -1,0 +1,56 @@
+# ~/.aliases — Loadout base aliases
+# Managed by Loadout. Extend via ~/.zshrc.local or ~/.zshrc.d/*.zsh
+
+# ---------------------------------------------------------------------------
+# Navigation
+# ---------------------------------------------------------------------------
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+
+# ---------------------------------------------------------------------------
+# eza (modern ls replacement)
+# ---------------------------------------------------------------------------
+if command -v eza >/dev/null 2>&1; then
+    alias ls='eza'
+    alias ll='eza -l --git'
+    alias la='eza -la --git'
+    alias lt='eza --tree --level=2'
+else
+    alias ll='ls -lh'
+    alias la='ls -lah'
+fi
+
+# ---------------------------------------------------------------------------
+# bat (modern cat replacement)
+# ---------------------------------------------------------------------------
+if command -v bat >/dev/null 2>&1; then
+    alias cat='bat --paging=never'
+fi
+
+# ---------------------------------------------------------------------------
+# Git shortcuts
+# ---------------------------------------------------------------------------
+alias g='git'
+alias gs='git status'
+alias gd='git diff'
+alias gl='git log --oneline --graph --decorate -20'
+alias gp='git pull'
+alias gco='git checkout'
+alias gcb='git checkout -b'
+alias gc='git commit'
+alias gca='git commit --amend --no-edit'
+alias gps='git push'
+
+# ---------------------------------------------------------------------------
+# Safety
+# ---------------------------------------------------------------------------
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+alias reload='source ~/.zshrc'
+alias path='echo $PATH | tr ":" "\n"'

--- a/dotfiles/base/.gitconfig
+++ b/dotfiles/base/.gitconfig
@@ -1,0 +1,45 @@
+# ~/.gitconfig — Loadout base git configuration
+# Managed by Loadout. Identity goes in ~/.gitconfig.local
+
+[core]
+    excludesFile = ~/.gitignore_global
+    editor = vim
+    autocrlf = input
+    pager = less -FRX
+
+[init]
+    defaultBranch = main
+
+[pull]
+    rebase = true
+
+[push]
+    default = current
+    autoSetupRemote = true
+
+[fetch]
+    prune = true
+
+[diff]
+    algorithm = histogram
+
+[merge]
+    conflictStyle = zdiff3
+
+[rebase]
+    autoSquash = true
+    autoStash = true
+
+[alias]
+    st = status
+    co = checkout
+    br = branch
+    ci = commit
+    lg = log --oneline --graph --decorate --all
+    unstage = reset HEAD --
+    last = log -1 HEAD
+    amend = commit --amend --no-edit
+
+[include]
+    path = ~/.gitconfig.local
+    path = ~/.gitconfig.d/org.gitconfig

--- a/dotfiles/base/.zshrc
+++ b/dotfiles/base/.zshrc
@@ -1,0 +1,134 @@
+# ~/.zshrc — Loadout base shell configuration
+# Managed by Loadout. Extend via ~/.zshrc.d/*.zsh and ~/.zshrc.local
+
+# ---------------------------------------------------------------------------
+# PATH
+# ---------------------------------------------------------------------------
+# Homebrew (auto-detect ARM vs Intel)
+if [[ -d /opt/homebrew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -d /usr/local/Homebrew ]]; then
+    eval "$(/usr/local/Homebrew/bin/brew shellenv)"
+fi
+
+# User paths
+[[ -d "$HOME/bin" ]] && export PATH="$HOME/bin:$PATH"
+[[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+HISTFILE="$HOME/.zsh_history"
+HISTSIZE=50000
+SAVEHIST=50000
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_FIND_NO_DUPS
+setopt SHARE_HISTORY
+setopt INC_APPEND_HISTORY
+setopt HIST_REDUCE_BLANKS
+
+# ---------------------------------------------------------------------------
+# Completion
+# ---------------------------------------------------------------------------
+autoload -Uz compinit && compinit
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+[[ -f "$HOME/.aliases" ]] && source "$HOME/.aliases"
+
+# ---------------------------------------------------------------------------
+# nvm
+# ---------------------------------------------------------------------------
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+    source "$NVM_DIR/nvm.sh"
+    [[ -s "$NVM_DIR/bash_completion" ]] && source "$NVM_DIR/bash_completion"
+fi
+
+# ---------------------------------------------------------------------------
+# pyenv
+# ---------------------------------------------------------------------------
+if command -v pyenv >/dev/null 2>&1; then
+    export PYENV_ROOT="${PYENV_ROOT:-$HOME/.pyenv}"
+    eval "$(pyenv init -)"
+fi
+
+# ---------------------------------------------------------------------------
+# zoxide
+# ---------------------------------------------------------------------------
+if command -v zoxide >/dev/null 2>&1; then
+    eval "$(zoxide init zsh)"
+fi
+
+# ---------------------------------------------------------------------------
+# fzf
+# ---------------------------------------------------------------------------
+if command -v fzf >/dev/null 2>&1; then
+    # fzf 0.48+ uses built-in shell integration
+    if [[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh" ]]; then
+        source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh"
+        source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/completion.zsh"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Background git fetch check
+# ---------------------------------------------------------------------------
+__loadout_git_check() {
+    local stamp_file="$HOME/.loadout/last-fetch"
+    local now
+    now="$(date +%s)"
+
+    # Only run in a git repo
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
+
+    # Throttle: once per hour
+    if [[ -f "$stamp_file" ]]; then
+        local last
+        last="$(cat "$stamp_file" 2>/dev/null)"
+        if [[ -n "$last" ]] && (( now - last < 3600 )); then
+            # Check if we already know we're behind
+            local behind
+            behind="$(git rev-list --count HEAD..@{u} 2>/dev/null)"
+            if [[ -n "$behind" && "$behind" -gt 0 ]]; then
+                printf '\033[1;33m[loadout]\033[0m %s is %d commit(s) behind upstream\n' \
+                    "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" "$behind"
+            fi
+            return
+        fi
+    fi
+
+    # Background fetch
+    {
+        git fetch --quiet 2>/dev/null
+        mkdir -p "$(dirname "$stamp_file")"
+        date +%s > "$stamp_file"
+    } &!
+
+    # Check current state (from before fetch)
+    local behind
+    behind="$(git rev-list --count HEAD..@{u} 2>/dev/null)"
+    if [[ -n "$behind" && "$behind" -gt 0 ]]; then
+        printf '\033[1;33m[loadout]\033[0m %s is %d commit(s) behind upstream\n' \
+            "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" "$behind"
+    fi
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd __loadout_git_check
+
+# ---------------------------------------------------------------------------
+# Overlay: ~/.zshrc.d/*.zsh (numeric-sorted)
+# ---------------------------------------------------------------------------
+if [[ -d "$HOME/.zshrc.d" ]]; then
+    for f in "$HOME"/.zshrc.d/*.zsh(N); do
+        source "$f"
+    done
+    unset f
+fi
+
+# ---------------------------------------------------------------------------
+# Private overrides (last)
+# ---------------------------------------------------------------------------
+[[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"

--- a/dotfiles/devbox/50-devbox.zsh
+++ b/dotfiles/devbox/50-devbox.zsh
@@ -1,0 +1,38 @@
+# 50-devbox.zsh — Developer tools overlay
+# Installed to ~/.zshrc.d/ by Loadout install-devbox.sh
+
+# ---------------------------------------------------------------------------
+# Docker
+# ---------------------------------------------------------------------------
+if command -v docker >/dev/null 2>&1; then
+    alias dk='docker'
+    alias dkc='docker compose'
+    alias dkps='docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+    alias dkprune='docker system prune -af'
+fi
+
+# ---------------------------------------------------------------------------
+# GitHub CLI
+# ---------------------------------------------------------------------------
+if command -v gh >/dev/null 2>&1; then
+    alias ghpr='gh pr create'
+    alias ghprs='gh pr list'
+    alias ghprv='gh pr view --web'
+fi
+
+# ---------------------------------------------------------------------------
+# Node / npm
+# ---------------------------------------------------------------------------
+if command -v npm >/dev/null 2>&1; then
+    alias ni='npm install'
+    alias nr='npm run'
+    alias nt='npm test'
+    alias nrb='npm run build'
+fi
+
+# ---------------------------------------------------------------------------
+# Lazygit
+# ---------------------------------------------------------------------------
+if command -v lazygit >/dev/null 2>&1; then
+    alias lg='lazygit'
+fi

--- a/globals/globals.base.sh
+++ b/globals/globals.base.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# globals.base.sh — Install global language runtimes and tools
+# Idempotent: safe to re-run.
+#
+
+set -euo pipefail
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+skip()  { printf '\033[1;33m[SKIP]\033[0m  %s\n' "$1"; }
+install_msg() { printf '\033[1;32m[INSTALL]\033[0m  %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# nvm + Node LTS
+# ---------------------------------------------------------------------------
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
+if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+    skip "nvm already installed at $NVM_DIR"
+else
+    install_msg "Installing nvm..."
+    PROFILE=/dev/null bash -c 'curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash'
+fi
+
+# Source nvm for this session
+# shellcheck source=/dev/null
+[[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+
+if command -v nvm >/dev/null 2>&1; then
+    if nvm ls --no-colors lts/* 2>/dev/null | grep -q "N/A"; then
+        install_msg "Installing Node LTS..."
+        nvm install --lts
+        nvm alias default 'lts/*'
+    else
+        skip "Node LTS already installed"
+    fi
+else
+    info "nvm not available in this session — restart shell and re-run"
+fi
+
+# ---------------------------------------------------------------------------
+# pyenv + Python
+# ---------------------------------------------------------------------------
+if command -v pyenv >/dev/null 2>&1; then
+    skip "pyenv already installed"
+    eval "$(pyenv init -)"
+
+    latest_python="$(pyenv install --list 2>/dev/null | grep -E '^\s+3\.[0-9]+\.[0-9]+$' | tail -1 | tr -d ' ')"
+    if [[ -n "$latest_python" ]]; then
+        if pyenv versions --bare | grep -qF "$latest_python"; then
+            skip "Python $latest_python already installed"
+        else
+            install_msg "Installing Python $latest_python..."
+            pyenv install "$latest_python"
+        fi
+        pyenv global "$latest_python"
+    fi
+else
+    info "pyenv not found — install via Homebrew first (brew install pyenv)"
+fi
+
+# ---------------------------------------------------------------------------
+# Claude Code
+# ---------------------------------------------------------------------------
+if command -v claude >/dev/null 2>&1; then
+    skip "Claude Code already installed"
+else
+    install_msg "Installing Claude Code..."
+    # Note: inspect installer for profile suppression options if it modifies shell configs
+    curl -fsSL https://claude.ai/install.sh | bash
+fi
+
+info "globals.base.sh complete"

--- a/globals/globals.devbox.sh
+++ b/globals/globals.devbox.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# globals.devbox.sh — Install global dev packages (npm, pip)
+# Idempotent: safe to re-run.
+#
+
+set -euo pipefail
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+skip()  { printf '\033[1;33m[SKIP]\033[0m  %s\n' "$1"; }
+install_msg() { printf '\033[1;32m[INSTALL]\033[0m  %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Global npm packages
+# ---------------------------------------------------------------------------
+if command -v npm >/dev/null 2>&1; then
+    npm_globals=(
+        typescript
+        ts-node
+        prettier
+        eslint
+    )
+    for pkg in "${npm_globals[@]}"; do
+        if npm list -g "$pkg" >/dev/null 2>&1; then
+            skip "npm: $pkg already installed"
+        else
+            install_msg "npm: installing $pkg..."
+            npm install -g "$pkg"
+        fi
+    done
+else
+    info "npm not found — run globals.base.sh first"
+fi
+
+# ---------------------------------------------------------------------------
+# Global pip packages
+# ---------------------------------------------------------------------------
+if command -v pip3 >/dev/null 2>&1; then
+    pip_globals=(
+        black
+        ruff
+        mypy
+    )
+    for pkg in "${pip_globals[@]}"; do
+        if pip3 show "$pkg" >/dev/null 2>&1; then
+            skip "pip: $pkg already installed"
+        else
+            install_msg "pip: installing $pkg..."
+            pip3 install "$pkg"
+        fi
+    done
+else
+    info "pip3 not found — run globals.base.sh first"
+fi
+
+info "globals.devbox.sh complete"

--- a/iterm2/generate-profile.py
+++ b/iterm2/generate-profile.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate an iTerm2 Dynamic Profile JSON file.
+
+Uses only Python stdlib. Outputs a JSON file suitable for placement in:
+    ~/Library/Application Support/iTerm2/DynamicProfiles/
+
+Usage:
+    python3 generate-profile.py --name "My Profile"
+    python3 generate-profile.py --name "Dev" --colors schemes/Solarized.itermcolors --output profile.json
+"""
+
+import argparse
+import json
+import os
+import plistlib
+import sys
+import tempfile
+import uuid
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate an iTerm2 Dynamic Profile JSON"
+    )
+    parser.add_argument("--name", required=True, help="Profile name")
+    parser.add_argument(
+        "--font", default="MesloLGS-NF", help="Font PostScript name (default: MesloLGS-NF)"
+    )
+    parser.add_argument(
+        "--font-size", type=int, default=13, help="Font size (default: 13)"
+    )
+    parser.add_argument(
+        "--colors", help="Path to .itermcolors file"
+    )
+    parser.add_argument(
+        "--guid", default=None, help="Profile GUID (default: random UUID)"
+    )
+    parser.add_argument(
+        "--output", default=None, help="Output file path (default: stdout)"
+    )
+    return parser.parse_args()
+
+
+def load_itermcolors(path):
+    """Load an .itermcolors plist and convert to Dynamic Profile color format."""
+    try:
+        with open(path, "rb") as f:
+            colors = plistlib.load(f)
+    except Exception as e:
+        sys.exit(f"error: cannot read itermcolors file: {e}")
+
+    result = {}
+    for key, value in colors.items():
+        if not isinstance(value, dict):
+            continue
+        color = {}
+        # Map Color Space Name -> Color Space
+        if "Color Space Name" in value:
+            color["Color Space"] = value["Color Space Name"]
+        elif "Color Space" in value:
+            color["Color Space"] = value["Color Space"]
+
+        # Normalize color components to float
+        for component in ("Red Component", "Green Component", "Blue Component"):
+            if component in value:
+                color[component] = float(value[component])
+
+        # Default alpha to 1.0
+        color["Alpha Component"] = float(value.get("Alpha Component", 1.0))
+
+        result[key] = color
+
+    return result
+
+
+def build_profile(name, font, font_size, guid, colors):
+    """Build the profile dictionary."""
+    font_string = f"{font} {font_size}"
+
+    profile = {
+        "Name": name,
+        "Guid": guid,
+        "Dynamic Profile Parent Name": "Default",
+        "Normal Font": font_string,
+        "Non Ascii Font": font_string,
+        "Use Non-ASCII Font": False,
+        "Option Key Sends": 2,
+        "Unlimited Scrollback": True,
+        "Custom Directory": "Recycle",
+    }
+
+    if colors:
+        profile.update(colors)
+
+    return profile
+
+
+def write_output(data, output_path):
+    """Write JSON output, using atomic writes for files."""
+    json_str = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+    if output_path is None:
+        sys.stdout.write(json_str)
+        return
+
+    # Atomic write: tempfile in same directory, then rename
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=output_dir, suffix=".json.tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(json_str)
+            os.rename(tmp_path, output_path)
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+    except Exception as e:
+        sys.exit(f"error: cannot write output: {e}")
+
+
+def main():
+    args = parse_args()
+
+    guid = args.guid or str(uuid.uuid4())
+
+    colors = None
+    if args.colors:
+        colors = load_itermcolors(args.colors)
+
+    profile = build_profile(args.name, args.font, args.font_size, guid, colors)
+    data = {"Profiles": [profile]}
+
+    write_output(data, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/iterm2/schemes/README.md
+++ b/iterm2/schemes/README.md
@@ -1,0 +1,3 @@
+# iTerm2 Color Schemes
+
+Place `.itermcolors` files in this directory. They can be passed to `generate-profile.py` via the `--colors` flag.

--- a/macos/com.oakensoul.display-defaults.plist
+++ b/macos/com.oakensoul.display-defaults.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.oakensoul.display-defaults</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>$HOME/dotfiles/macos/display-watch.sh --daemon</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/tmp/com.oakensoul.display-defaults.out.log</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/com.oakensoul.display-defaults.err.log</string>
+</dict>
+</plist>

--- a/macos/defaults-base.sh
+++ b/macos/defaults-base.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# defaults-base.sh — macOS system defaults (base layer)
+# Safe to re-run. Applies to all machine types.
+#
+
+# ---------------------------------------------------------------------------
+# Dock
+# ---------------------------------------------------------------------------
+defaults write com.apple.dock orientation -string "left"
+defaults write com.apple.dock tilesize -int 25
+defaults write com.apple.dock magnification -bool true
+defaults write com.apple.dock largesize -int 75
+defaults write com.apple.dock autohide -bool false
+defaults write com.apple.dock show-recents -bool false
+
+# ---------------------------------------------------------------------------
+# Keyboard
+# ---------------------------------------------------------------------------
+defaults write NSGlobalDomain KeyRepeat -int 2
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+# ---------------------------------------------------------------------------
+# Finder
+# ---------------------------------------------------------------------------
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+
+# ---------------------------------------------------------------------------
+# Screenshots
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/Screenshots"
+defaults write com.apple.screencapture location -string "$HOME/Screenshots"
+defaults write com.apple.screencapture disable-shadow -bool true
+
+# ---------------------------------------------------------------------------
+# Security
+# ---------------------------------------------------------------------------
+defaults write com.apple.screensaver askForPassword -int 1
+defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+# ---------------------------------------------------------------------------
+# Apply changes
+# ---------------------------------------------------------------------------
+killall Dock Finder SystemUIServer 2>/dev/null || true

--- a/macos/defaults-desktop.sh
+++ b/macos/defaults-desktop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# defaults-desktop.sh — Power management for desktops (Mac Mini, Mac Pro, iMac)
+# Never sleep, display sleep after 10 minutes, no screensaver.
+#
+
+sudo pmset -a sleep 0
+sudo pmset -a displaysleep 10
+sudo pmset -a disksleep 0
+defaults write com.apple.screensaver idleTime -int 0

--- a/macos/defaults-laptop-connected.sh
+++ b/macos/defaults-laptop-connected.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# defaults-laptop-connected.sh — Power management for docked laptops (external display)
+# No sleep on AC (desktop-like behavior), battery still conserves.
+#
+
+# Battery (still conserve)
+sudo pmset -b sleep 15
+sudo pmset -b displaysleep 5
+sudo pmset -b disksleep 10
+
+# AC Power (docked: never sleep)
+sudo pmset -c sleep 0
+sudo pmset -c displaysleep 10
+sudo pmset -c disksleep 0

--- a/macos/defaults-laptop-solo.sh
+++ b/macos/defaults-laptop-solo.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# defaults-laptop-solo.sh — Power management for laptops with no external display
+# Battery-friendly sleep timers.
+#
+
+# Battery
+sudo pmset -b sleep 15
+sudo pmset -b displaysleep 5
+sudo pmset -b disksleep 10
+
+# AC Power
+sudo pmset -c sleep 30
+sudo pmset -c displaysleep 10
+sudo pmset -c disksleep 15

--- a/macos/display-watch.sh
+++ b/macos/display-watch.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# display-watch.sh — Detect hardware model and display count, apply appropriate power profile
+#
+# Usage:
+#   display-watch.sh --apply-once    # Detect and apply, then exit
+#   display-watch.sh --daemon        # Poll every 30s, reapply on change
+#
+# Testable via environment variables:
+#   HW_MODEL_CMD="echo MacBookPro18,1" DISPLAY_INFO_CMD="cat test-displays.txt" ./display-watch.sh --apply-once
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_FILE="$HOME/.loadout/logs/display-watch.log"
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+
+get_hw_model() {
+    ${HW_MODEL_CMD:-sysctl -n hw.model}
+}
+
+get_display_count() {
+    local timeout_cmd=""
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout 10"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        timeout_cmd="gtimeout 10"
+    fi
+    # shellcheck disable=SC2086
+    ${timeout_cmd} ${DISPLAY_INFO_CMD:-system_profiler SPDisplaysDataType} 2>/dev/null | grep -c "Resolution:" || echo "0"
+}
+
+apply_profile() {
+    local model="$1"
+    local displays="$2"
+
+    info "Hardware: $model, Displays: $displays"
+
+    case "$model" in
+        MacBook*)
+            if [[ "$displays" -ge 2 ]]; then
+                info "Applying laptop-connected profile (docked)"
+                source "$SCRIPT_DIR/defaults-laptop-connected.sh"
+            else
+                info "Applying laptop-solo profile"
+                source "$SCRIPT_DIR/defaults-laptop-solo.sh"
+            fi
+            ;;
+        *)
+            info "Applying desktop profile"
+            source "$SCRIPT_DIR/defaults-desktop.sh"
+            ;;
+    esac
+}
+
+run_once() {
+    local model displays
+    model="$(get_hw_model)"
+    displays="$(get_display_count)"
+    apply_profile "$model" "$displays"
+}
+
+run_daemon() {
+    mkdir -p "$(dirname "$LOG_FILE")"
+    info "Starting display-watch daemon (logging to $LOG_FILE)"
+
+    local last_count=""
+    while true; do
+        local model displays
+        model="$(get_hw_model)"
+        displays="$(get_display_count)"
+
+        if [[ "$displays" != "$last_count" ]]; then
+            echo "$(date '+%Y-%m-%d %H:%M:%S') Display count changed: ${last_count:-none} -> $displays" | tee -a "$LOG_FILE"
+            apply_profile "$model" "$displays"
+            last_count="$displays"
+        fi
+
+        sleep 30
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    --apply-once)
+        run_once
+        ;;
+    --daemon)
+        run_daemon
+        ;;
+    *)
+        echo "Usage: display-watch.sh [--apply-once|--daemon]" >&2
+        exit 1
+        ;;
+esac

--- a/slack/README.md
+++ b/slack/README.md
@@ -1,0 +1,3 @@
+# Slack
+
+Placeholder for Slack configurations managed by Loadout.

--- a/test/validate.sh
+++ b/test/validate.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# validate.sh — Static validation for the Loadout repository
+# Runs all checks, reports all failures, exits with error count.
+#
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+errors=0
+
+info()  { printf '\033[1;34m[INFO]\033[0m  %s\n' "$1"; }
+pass()  { printf '\033[1;32m[PASS]\033[0m  %s\n' "$1"; }
+fail()  { printf '\033[1;31m[FAIL]\033[0m  %s\n' "$1"; errors=$((errors + 1)); }
+
+# ---------------------------------------------------------------------------
+# 1. Shebang check
+# ---------------------------------------------------------------------------
+info "Checking shebangs..."
+while IFS= read -r f; do
+    first_line="$(head -1 "$f")"
+    case "$f" in
+        *.sh)
+            if [[ "$first_line" != "#!/usr/bin/env bash" ]]; then
+                fail "$f: expected #!/usr/bin/env bash, got: $first_line"
+            fi
+            ;;
+        *.py)
+            if [[ "$first_line" != "#!/usr/bin/env python3" ]]; then
+                fail "$f: expected #!/usr/bin/env python3, got: $first_line"
+            fi
+            ;;
+    esac
+done < <(find "$REPO_ROOT" -type f \( -name '*.sh' -o -name '*.py' \) -not -path '*/.git/*')
+pass "Shebangs"
+
+# ---------------------------------------------------------------------------
+# 2. Executable bit
+# ---------------------------------------------------------------------------
+info "Checking executable bits..."
+if command -v git >/dev/null 2>&1 && [ -d "$REPO_ROOT/.git" ]; then
+    while IFS= read -r line; do
+        mode="$(echo "$line" | awk '{print $1}')"
+        file="$(echo "$line" | awk '{print $4}')"
+        if [[ "$mode" != "100755" ]]; then
+            fail "$file: not executable in git (mode $mode)"
+        fi
+    done < <(cd "$REPO_ROOT" && git ls-files --stage '*.sh' '*.py' 2>/dev/null)
+fi
+pass "Executable bits"
+
+# ---------------------------------------------------------------------------
+# 3. shellcheck
+# ---------------------------------------------------------------------------
+info "Running shellcheck..."
+if command -v shellcheck >/dev/null 2>&1; then
+    while IFS= read -r f; do
+        if ! shellcheck --severity=warning "$f" >/dev/null 2>&1; then
+            fail "shellcheck: $f"
+            shellcheck --severity=warning "$f" 2>&1 | head -20
+        fi
+    done < <(find "$REPO_ROOT" -type f -name '*.sh' -not -path '*/.git/*')
+    pass "shellcheck"
+else
+    info "shellcheck not found, skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Python syntax
+# ---------------------------------------------------------------------------
+info "Checking Python syntax..."
+while IFS= read -r f; do
+    if ! python3 -m py_compile "$f" 2>/dev/null; then
+        fail "Python syntax: $f"
+    fi
+done < <(find "$REPO_ROOT" -type f -name '*.py' -not -path '*/.git/*')
+pass "Python syntax"
+
+# ---------------------------------------------------------------------------
+# 5. JSON validation
+# ---------------------------------------------------------------------------
+info "Validating JSON files..."
+while IFS= read -r f; do
+    if ! python3 -m json.tool "$f" >/dev/null 2>&1; then
+        fail "Invalid JSON: $f"
+    fi
+done < <(find "$REPO_ROOT" -type f -name '*.json' -not -path '*/.git/*')
+pass "JSON"
+
+# ---------------------------------------------------------------------------
+# 6. Plist validation
+# ---------------------------------------------------------------------------
+info "Validating plist files..."
+while IFS= read -r f; do
+    if ! python3 -c "import plistlib; plistlib.load(open('$f','rb'))" 2>/dev/null; then
+        fail "Invalid plist: $f"
+    fi
+done < <(find "$REPO_ROOT" -type f -name '*.plist' -not -path '*/.git/*')
+pass "Plists"
+
+# ---------------------------------------------------------------------------
+# 7. Brewfile syntax
+# ---------------------------------------------------------------------------
+info "Checking Brewfile syntax..."
+while IFS= read -r f; do
+    line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        # Skip blank lines and comments
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+        if ! echo "$line" | grep -qE '^(tap|brew|cask|mas|vscode)\s+'; then
+            fail "$f:$line_num: invalid Brewfile line: $line"
+        fi
+    done < "$f"
+done < <(find "$REPO_ROOT" -type f -name 'Brewfile*' -not -path '*/.git/*')
+pass "Brewfiles"
+
+# ---------------------------------------------------------------------------
+# 8. Secrets scan
+# ---------------------------------------------------------------------------
+info "Scanning for secrets..."
+secret_patterns='(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AKIA[A-Z0-9]{16}|xoxb-[0-9]|-----BEGIN.*PRIVATE KEY-----)'
+while IFS= read -r f; do
+    if grep -qE "$secret_patterns" "$f" 2>/dev/null; then
+        fail "Possible secret in: $f"
+    fi
+done < <(find "$REPO_ROOT" -type f \( -name '*.sh' -o -name '*.py' -o -name '*.json' -o -name '*.yml' -o -name '*.yaml' \) -not -path '*/.git/*' -not -name 'validate.sh')
+pass "Secrets scan"
+
+# ---------------------------------------------------------------------------
+# 9. Hardcoded path scan
+# ---------------------------------------------------------------------------
+info "Scanning for hardcoded paths..."
+while IFS= read -r f; do
+    if grep -qE '(/Users/|/home/)' "$f" 2>/dev/null; then
+        fail "Hardcoded user path in: $f"
+    fi
+done < <(find "$REPO_ROOT" -type f \( -name '*.sh' -o -name '*.py' \) -not -path '*/.git/*' -not -name 'validate.sh')
+pass "Hardcoded paths"
+
+# ---------------------------------------------------------------------------
+# 10. Static idempotency checks
+# ---------------------------------------------------------------------------
+info "Checking idempotency patterns..."
+while IFS= read -r f; do
+    # Flag >> appends that aren't guarded
+    if grep -nE '>>' "$f" | grep -vE '(>>|/dev/null|\.log)' >/dev/null 2>&1; then
+        # Check if the line has a guard (if/test/[[ before it)
+        while IFS= read -r match; do
+            line_num="$(echo "$match" | cut -d: -f1)"
+            # Look for guard in preceding lines
+            prev_start=$((line_num > 3 ? line_num - 3 : 1))
+            context="$(sed -n "${prev_start},${line_num}p" "$f")"
+            if ! echo "$context" | grep -qE '(if |then|\[\[|\[ |grep -q)'; then
+                fail "$f:$line_num: unguarded >> append"
+            fi
+        done < <(grep -nE '>>' "$f" | grep -vE '(/dev/null|\.log)')
+    fi
+    # Flag mkdir without -p (only actual mkdir commands, not references in strings)
+    if grep -nE '^\s*mkdir [^-]' "$f" | grep -vE 'mkdir -p' >/dev/null 2>&1; then
+        fail "$f: mkdir without -p flag"
+    fi
+done < <(find "$REPO_ROOT" -type f -name '*.sh' -not -path '*/.git/*' -not -name 'validate.sh')
+pass "Idempotency patterns"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [[ "$errors" -eq 0 ]]; then
+    printf '\033[1;32mAll checks passed.\033[0m\n'
+    exit 0
+else
+    printf '\033[1;31m%d check(s) failed.\033[0m\n' "$errors"
+    exit "$errors"
+fi

--- a/webapps/README.md
+++ b/webapps/README.md
@@ -1,0 +1,3 @@
+# Web Apps
+
+Placeholder for web application configurations managed by Loadout.


### PR DESCRIPTION
## Summary

- **Replaces stow-based dotfiles** with Loadout, a layered macOS machine configuration system
- **Bootstrap scripts**: `install-base.sh` (Xcode CLI, Homebrew, core packages, runtimes, macOS defaults), `install-user.sh` (backup + copy dotfiles, create `~/.loadout/`), `install-devbox.sh` (dev tools, shell overlay, display detection)
- **Base dotfiles**: `.zshrc` (PATH, history, completion, nvm/pyenv/zoxide/fzf, background git fetch, overlay hooks), `.gitconfig` (core settings, aliases, no `[user]`), `.aliases` (eza/bat wrappers, git shortcuts)
- **macOS defaults**: Dock, Keyboard, Finder, Screenshots, Security, plus power profiles for desktop/laptop-solo/laptop-connected with automatic display detection daemon
- **Claude Code statusline**: shows repo, GitHub username, branch, git status, AIDA status with version comparison against installed plugin, model, context %, and session cost
- **Validation**: 10-check `test/validate.sh` (shellcheck, JSON/plist, secrets scan, path scan, idempotency) with GitHub Actions CI
- **iTerm2 Dynamic Profile generator** (Python stdlib only)

## Test plan

- [x] `test/validate.sh` passes all 10 checks including shellcheck
- [ ] Verify bootstrap scripts on a fresh macOS machine or VM
- [ ] Confirm statusline renders correctly in Claude Code session
- [ ] Validate CI workflow runs on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)