### PR TITLE
Add comprehensive setup guide and update all documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Merge strategy: shell concatenation, gitconfig `[include]`, JSON deep merge via 
 
 ### Directory Layout
 
-- **bootstrap/** — Installation scripts (`install-base.sh`, `install-user.sh`, `install-devbox.sh`)
+- **bootstrap/** — Installation scripts (`install-base.sh`, `install-user.sh`, `install-devbox.sh`). Manual alternative to `loadout init`.
 - **brewfiles/** — Homebrew bundle files (`Brewfile.base`, `Brewfile.devbox`)
 - **globals/** — Global runtime installers (`globals.base.sh`, `globals.devbox.sh`)
 - **dotfiles/base/** — Core dotfiles (`.zshrc`, `.gitconfig`, `.aliases`)
@@ -26,13 +26,14 @@ Merge strategy: shell concatenation, gitconfig `[include]`, JSON deep merge via 
 - **claude/** — Claude Code config templates and MCP configs
 - **macos/** — System defaults scripts and power management
 - **iterm2/** — iTerm2 Dynamic Profile generator (Python, stdlib only)
+- **docs/** — Setup guide and architecture documentation
 - **test/** — Validation script and CI workflow
 - **webapps/, slack/, canvas/** — Placeholder directories for future configs
 
 ### Key Design Patterns
 
 - **Idempotent scripts** — all `.sh` files use `command -v` guards, check before acting
-- **No symlinks** — files are copied to `~/`; future `loadout build` merges layers
+- **No symlinks** — files are copied to `~/`; `loadout build` merges layers
 - **Overlay hooks** — `~/.zshrc.local`, `~/.zshrc.d/*.zsh` (numeric prefix ordering), `~/.gitconfig.local`, `~/.gitconfig.d/`
 - **State directory** — `~/.loadout/` holds `backups/`, `logs/`, future `manifest.json`
 - **nvm via curl** (not Homebrew), **pyenv via Homebrew**, profile suppression with `PROFILE=/dev/null`
@@ -42,7 +43,16 @@ Merge strategy: shell concatenation, gitconfig `[include]`, JSON deep merge via 
 ## Common Commands
 
 ```bash
-# Bootstrap a new machine
+# Bootstrap a new machine (recommended — see docs/SETUP.md)
+loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
+
+# Day-to-day
+loadout update                   # Pull repos, rebuild, brew bundle
+loadout upgrade                  # update + brew upgrade
+loadout build                    # Rebuild merged dotfiles
+loadout check                    # Read-only health checks
+
+# Manual bootstrap (alternative to loadout init)
 ./bootstrap/install-base.sh
 ./bootstrap/install-user.sh
 ./bootstrap/install-devbox.sh    # optional
@@ -75,3 +85,8 @@ python3 iterm2/generate-profile.py --name "My Profile" --output ~/Library/Applic
 ### Testing
 
 `test/validate.sh` runs 10 checks — shellcheck, JSON/plist validation, secrets scan, path scan, idempotency checks. CI runs on every push/PR via `.github/workflows/validate.yml`.
+
+## Further Reading
+
+- **[docs/SETUP.md](docs/SETUP.md)** — Step-by-step getting started guide
+- **[docs/architecture/README.md](docs/architecture/README.md)** — C4 diagrams, merge strategies, data flows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Merge strategy: shell concatenation, gitconfig `[include]`, JSON deep merge via 
 - **Idempotent scripts** — all `.sh` files use `command -v` guards, check before acting
 - **No symlinks** — files are copied to `~/`; `loadout build` merges layers
 - **Overlay hooks** — `~/.zshrc.local`, `~/.zshrc.d/*.zsh` (numeric prefix ordering), `~/.gitconfig.local`, `~/.gitconfig.d/`
-- **State directory** — `~/.loadout/` holds `backups/`, `logs/`, future `manifest.json`
+- **State directory** — `~/.loadout/` holds `backups/`, `logs/`, `manifest.json`
 - **nvm via curl** (not Homebrew), **pyenv via Homebrew**, profile suppression with `PROFILE=/dev/null`
 - **1Password CLI** (`op`) for secrets, SSH via 1Password SSH agent
 - **pmset** for power management (not deprecated systemsetup)

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ The recommended way to set up a new machine is with the `loadout` CLI:
 # 1. Install Homebrew (if not already installed)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# 2. Install loadout
-pip3 install oakensoul-loadout
+# 2. Install loadout (not yet on PyPI — install from source)
+git clone https://github.com/oakensoul/loadout.git ~/.loadout-cli
+pip3 install ~/.loadout-cli
 
 # 3. Bootstrap your machine
 loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
 ```
 
-This runs a fully automated 12-step bootstrap that clones repos, generates SSH keys, installs packages, builds your dotfiles, and configures macOS defaults.
+This runs a fully automated 13-step bootstrap that clones repos, generates SSH keys, installs packages, builds your dotfiles, and configures macOS defaults.
 
 For the full walkthrough, see the **[Setup Guide](docs/SETUP.md)**.
 
@@ -47,8 +48,8 @@ For the full walkthrough, see the **[Setup Guide](docs/SETUP.md)**.
 If you prefer to run things step by step without the loadout CLI:
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/dotfiles
-cd ~/dotfiles
+git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
 
 ./bootstrap/install-base.sh      # Xcode CLI, Homebrew, base packages, macOS defaults
 ./bootstrap/install-user.sh      # Back up existing dotfiles, install base configs

--- a/README.md
+++ b/README.md
@@ -1,83 +1,102 @@
-# Loadout
+# Loadout — Dotfiles Base Layer
 
-A layered macOS machine configuration system. This is the **public base layer** — no personal information, no organization-specific content.
+A layered macOS machine configuration system. This is the **public base layer** containing sensible defaults for any macOS machine. No personal information, no organization-specific content.
 
-## Overview
+## How It Works
 
 Loadout replaces traditional symlink-based dotfiles with a **layered merge system**:
 
-- **Base layer** (this repo) — sensible defaults for any macOS machine
-- **Org layer** — team/company tools, standards, and configs
-- **Private layer** — personal identity, secrets, API keys
+```
+Base (this repo)          Sensible macOS defaults for everyone
+        |
+   Org layer              Team/company tools, standards, configs
+        |
+  Private layer           Personal identity, secrets, API keys
+```
 
-Each layer extends and overrides the one below it. Shell configs concatenate, gitconfigs use `[include]`, JSON merges deeply via `jq`.
+Each layer extends and overrides the one below it. Shell configs concatenate, gitconfigs use `[include]`, and JSON merges deeply. The [loadout CLI](https://github.com/oakensoul/loadout) orchestrates everything.
+
+## Prerequisites
+
+- **macOS 13 Ventura** or later
+- **Apple ID** (required for Xcode Command Line Tools)
+- **GitHub account**
+- **1Password account** (recommended, for secrets and SSH agent management)
 
 ## Quick Start
 
+The recommended way to set up a new machine is with the `loadout` CLI:
+
 ```bash
-# 1. Clone
-git clone https://github.com/oakensoul/dotfiles.git ~/dotfiles
-cd ~/dotfiles
+# 1. Install Homebrew (if not already installed)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# 2. Bootstrap base tools (Xcode CLI, Homebrew, core packages)
-./bootstrap/install-base.sh
+# 2. Install loadout
+pip3 install oakensoul-loadout
 
-# 3. Install base dotfiles
-./bootstrap/install-user.sh
-
-# 4. (Optional) Install dev tools
-./bootstrap/install-devbox.sh
+# 3. Bootstrap your machine
+loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
 ```
 
-## Structure
+This runs a fully automated 12-step bootstrap that clones repos, generates SSH keys, installs packages, builds your dotfiles, and configures macOS defaults.
+
+For the full walkthrough, see the **[Setup Guide](docs/SETUP.md)**.
+
+### Manual Bootstrap (Alternative)
+
+If you prefer to run things step by step without the loadout CLI:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+
+./bootstrap/install-base.sh      # Xcode CLI, Homebrew, base packages, macOS defaults
+./bootstrap/install-user.sh      # Back up existing dotfiles, install base configs
+./bootstrap/install-devbox.sh    # (Optional) Developer tools and overlay
+```
+
+See the [Setup Guide](docs/SETUP.md#manual-bootstrap) for details on this approach.
+
+## Repository Structure
 
 ```
 dotfiles/
-├── bootstrap/          # Installation scripts (base, user, devbox)
-├── brewfiles/          # Homebrew bundle files
-├── globals/            # Global language runtimes and tools
-├── dotfiles/           # Shell, git, and alias configs
-│   ├── base/           # Core dotfiles for any machine
-│   └── devbox/         # Developer overlay (zshrc.d drop-in)
-├── claude/             # Claude Code configuration templates
-├── macos/              # macOS system defaults and power management
-├── iterm2/             # iTerm2 profile generation
-├── test/               # Validation and CI
-├── webapps/            # Web app configs (placeholder)
-├── slack/              # Slack configs (placeholder)
-└── canvas/             # Canvas configs (placeholder)
+├── bootstrap/          Installation scripts (base, user, devbox)
+├── brewfiles/          Homebrew bundle files
+├── globals/            Global language runtimes and tools
+├── dotfiles/           Shell, git, and alias configs
+│   ├── base/           Core dotfiles for any machine
+│   └── devbox/         Developer overlay (zshrc.d drop-in)
+├── claude/             Claude Code configuration templates
+├── macos/              macOS system defaults and power management
+├── iterm2/             iTerm2 profile generation
+├── docs/               Architecture and setup documentation
+└── test/               Validation and CI
 ```
+
+## Documentation
+
+- **[Setup Guide](docs/SETUP.md)** — Step-by-step getting started guide
+- **[Architecture](docs/architecture/README.md)** — C4 diagrams, merge strategies, data flows
+- **[loadout CLI](https://github.com/oakensoul/loadout)** — The orchestrator tool documentation
+
+## The Loadout Ecosystem
+
+| Repository | Purpose |
+|---|---|
+| **[dotfiles](https://github.com/oakensoul/dotfiles)** (this repo) | Public base layer — universal macOS defaults |
+| **[loadout](https://github.com/oakensoul/loadout)** | CLI orchestrator — init, build, update, upgrade, check |
+| **dotfiles-private** | Private layer — org configs, secrets, identity (your own repo) |
+| **[devbox](https://github.com/oakensoul/devbox)** | Disposable SSH-only dev environments |
+| **[canvas](https://github.com/oakensoul/canvas)** | Ephemeral Claude Code workspace sessions |
 
 ## Design Principles
 
 - **Idempotent** — every script checks before acting, safe to re-run
-- **No symlinks** — files are copied; future `loadout build` will merge layers
-- **Overlay hooks** — `~/.zshrc.local`, `~/.zshrc.d/*.zsh`, `~/.gitconfig.local`, `~/.gitconfig.d/`
+- **No symlinks** — files are copied; `loadout build` merges layers
+- **Overlay hooks** — `~/.zshrc.d/*.zsh`, `~/.gitconfig.d/`, `~/.zshrc.local`, `~/.gitconfig.local`
 - **1Password CLI** (`op`) for secrets management and SSH agent
 - **No personal data** — this repo contains zero identity information
-
-## Overlay System
-
-### Shell
-- `~/.zshrc` — base shell config
-- `~/.zshrc.d/*.zsh` — numbered drop-ins (10-* org, 50-* devbox, 90-* private)
-- `~/.zshrc.local` — final private overrides (sourced last)
-
-### Git
-- `~/.gitconfig` — base git config (no `[user]` section)
-- `~/.gitconfig.d/` — include directory for org/team configs
-- `~/.gitconfig.local` — private identity and overrides
-
-### State Directory
-- `~/.loadout/` — managed state: `backups/`, `logs/`, future `manifest.json`
-
-## Bootstrap Scripts
-
-| Script | What it does |
-|--------|-------------|
-| `install-base.sh` | Xcode CLI tools, Homebrew, Brewfile.base, global runtimes, macOS defaults |
-| `install-user.sh` | Back up existing dotfiles, copy base configs to `~/`, create `~/.loadout/` |
-| `install-devbox.sh` | Brewfile.devbox, dev runtimes, devbox shell overlay, display detection |
 
 ## Validation
 
@@ -85,7 +104,16 @@ dotfiles/
 ./test/validate.sh
 ```
 
-Runs shellcheck, JSON/plist validation, secrets scanning, and portability checks. Also runs in CI on every push and PR.
+Runs shellcheck, JSON/plist validation, secrets scanning, and portability checks. Also runs in CI on every push and PR via `.github/workflows/validate.yml`.
+
+## Contributing
+
+1. Fork this repository
+2. Create a feature branch
+3. Ensure `./test/validate.sh` passes
+4. Submit a pull request
+
+All shell scripts must pass `shellcheck --severity=warning`. No personal data, API keys, or machine-specific paths should ever appear in this repo.
 
 ## License
 

--- a/bootstrap/install-base.sh
+++ b/bootstrap/install-base.sh
@@ -3,6 +3,9 @@
 # install-base.sh — Bootstrap base tools on a fresh macOS machine
 # Installs: Xcode CLI tools, Homebrew, Brewfile.base, global runtimes, macOS defaults
 #
+# Manual alternative to `loadout init`. See docs/SETUP.md for the recommended
+# automated approach.
+#
 
 set -euo pipefail
 

--- a/bootstrap/install-devbox.sh
+++ b/bootstrap/install-devbox.sh
@@ -3,6 +3,9 @@
 # install-devbox.sh — Install developer tools and overlay
 # Requires: install-base.sh has been run (Homebrew available)
 #
+# Manual alternative to `loadout init`. See docs/SETUP.md for the recommended
+# automated approach.
+#
 
 set -euo pipefail
 

--- a/bootstrap/install-user.sh
+++ b/bootstrap/install-user.sh
@@ -3,6 +3,9 @@
 # install-user.sh — Install base dotfiles to ~/
 # Creates ~/.loadout/, backs up existing files, copies base configs
 #
+# Manual alternative to `loadout init`. See docs/SETUP.md for the recommended
+# automated approach.
+#
 
 set -euo pipefail
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,578 @@
+# Setup Guide
+
+A step-by-step guide to setting up your macOS machine with the Loadout configuration system.
+
+---
+
+## Table of Contents
+
+1. [Before You Begin](#1-before-you-begin)
+2. [Initial Setup](#2-initial-setup)
+3. [What Just Happened](#3-what-just-happened)
+4. [Customizing Your Setup](#4-customizing-your-setup)
+5. [Day-to-Day Usage](#5-day-to-day-usage)
+6. [Advanced Topics](#6-advanced-topics)
+7. [Troubleshooting](#7-troubleshooting)
+8. [Uninstalling](#8-uninstalling)
+
+---
+
+## 1. Before You Begin
+
+### What This System Does
+
+Loadout takes a fresh macOS machine from factory settings to a fully configured development environment in a single command. It installs your tools, applies your shell and git configuration, sets macOS preferences, and manages updates going forward.
+
+Unlike traditional dotfile managers that symlink files from a single repo, Loadout uses a **layered merge system**. You maintain a public base layer (this repo) with sensible defaults, then overlay private and organization-specific configuration on top. This means you can share your base setup publicly without exposing personal details, and switch between different team contexts cleanly.
+
+### Prerequisites Checklist
+
+Before running the setup, make sure you have:
+
+- **macOS 13 Ventura or later** — Loadout targets modern macOS. Check your version in Apple menu > About This Mac.
+- **Apple ID** — Required for installing Xcode Command Line Tools. If you are on a managed machine, your IT department may need to allow this.
+- **GitHub account** — Your dotfiles repos are hosted on GitHub. [Create an account](https://github.com/signup) if you do not have one.
+- **1Password account** (recommended) — Loadout uses the 1Password CLI (`op`) for SSH key management and secrets. You can skip this, but you will need to manage SSH keys manually.
+
+### Fork or Clone?
+
+You have two options for getting started:
+
+- **Fork** (recommended) — Fork this repo to your own GitHub account. This lets you customize the base layer, add your own packages to the Brewfile, and push changes back. This is the right choice if you want to tailor the defaults.
+- **Clone** — Clone this repo directly. Good for evaluating or if you want to track upstream changes without maintaining your own fork. You can always fork later.
+
+### What Will Happen
+
+When you run `loadout init`, the CLI performs a 12-step bootstrap:
+
+1. Ensure Xcode Command Line Tools are installed
+2. Clone your dotfiles repo (this repo) to `~/.dotfiles`
+3. Clone your dotfiles-private repo to `~/.dotfiles-private`
+4. Generate an SSH key pair
+5. Register the SSH key with GitHub (using 1Password for the passphrase)
+6. Switch git remotes from HTTPS to SSH
+7. Build dotfiles (merge base + private + org layers into `~/`)
+8. Run Homebrew bundle (install all packages from assembled Brewfiles)
+9. Install global runtimes (Node.js via nvm, Python via pyenv, Claude Code)
+10. Build Claude Code configuration (merge MCP configs and CLAUDE.md)
+11. Apply macOS system defaults (Dock, Finder, keyboard, trackpad, screenshots)
+12. Set up display launch agent (auto-detect connected displays and apply power settings)
+13. Save configuration to `~/.dotfiles/.loadout.toml`
+
+---
+
+## 2. Initial Setup
+
+### Step 1: Fork This Repo
+
+On GitHub, fork this repository to your own account. If you plan to customize the base layer (adding packages, changing shell config), this is where those changes will live.
+
+### Step 2: Create Your Private Repo
+
+Create a private repository called `dotfiles-private` in your GitHub account. This will hold your personal identity, org-specific configs, and secrets references. The expected structure is:
+
+```
+dotfiles-private/
+├── brewfiles/
+│   ├── Brewfile.private            # Personal Homebrew packages
+│   └── orgs/
+│       └── Brewfile.YOUR_ORG       # Per-org Homebrew packages
+├── dotfiles/
+│   ├── base/                       # Private base dotfiles (optional)
+│   │   ├── .zshrc                  # Private shell config for all orgs
+│   │   └── .gitconfig              # Private git config for all orgs
+│   └── orgs/YOUR_ORG/
+│       ├── .zshrc                  # Org-specific shell config
+│       └── .gitconfig              # Org-specific git identity
+├── globals/
+│   └── orgs/
+│       └── globals.YOUR_ORG.sh     # Org-specific env vars and tools
+└── claude/
+    └── orgs/YOUR_ORG/
+        ├── mcp-YOUR_ORG.json       # Org-specific MCP servers
+        └── CLAUDE.md               # Org-specific Claude context
+```
+
+You can start with just a `dotfiles/orgs/YOUR_ORG/.gitconfig` containing your `[user]` section and build from there.
+
+### Step 3: Install Homebrew
+
+If Homebrew is not already installed:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Follow the post-install instructions to add Homebrew to your PATH.
+
+### Step 4: Install the Loadout CLI
+
+```bash
+pip3 install oakensoul-loadout
+```
+
+Verify the installation:
+
+```bash
+loadout --help
+```
+
+### Step 5: Run Loadout Init
+
+```bash
+loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
+```
+
+Replace `YOUR_USERNAME` with your GitHub username and `YOUR_ORG` with your org slug (e.g., `personal`). You can specify multiple orgs:
+
+```bash
+loadout init --user=YOUR_USERNAME --orgs=personal --orgs=work
+```
+
+To preview what will happen without making changes:
+
+```bash
+loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG --dry-run
+```
+
+The init process will prompt you for confirmation at key steps (SSH key generation, GitHub key registration). If any step fails, the process will tell you what went wrong and how to fix it before continuing.
+
+### Step 6: Verify
+
+Once init completes, verify everything is working:
+
+```bash
+loadout check
+```
+
+This runs read-only health checks and reports the status of your setup.
+
+---
+
+## 3. What Just Happened
+
+After `loadout init` completes, here is what was created and configured on your machine.
+
+### Directory Structure
+
+| Path | What It Is |
+|---|---|
+| `~/.dotfiles/` | Clone of your dotfiles repo (public base layer) |
+| `~/.dotfiles-private/` | Clone of your dotfiles-private repo (private/org layer) |
+| `~/.dotfiles/.loadout.toml` | Loadout configuration (your username, active orgs, tool versions) |
+| `~/.dotfiles/build/` | Staging area for merged dotfile output |
+| `~/.dotfiles/backups/` | Timestamped backups of overwritten files |
+| `~/.loadout/` | Runtime state directory (logs, backups) |
+| `~/.zshrc.d/` | Shell overlay directory (numbered drop-in scripts) |
+| `~/.gitconfig.d/` | Git config overlay directory (per-org includes) |
+| `~/.claude/` | Claude Code config (mcp.json, CLAUDE.md, provider scripts) |
+
+### What Got Installed
+
+- **Homebrew packages** from `Brewfile.base` plus any org-specific Brewfiles
+- **Node.js** via nvm (latest LTS)
+- **Python** via pyenv
+- **Claude Code** (global npm package)
+- Any additional global packages defined in your org globals scripts
+
+### What Got Configured
+
+- **Shell** — `~/.zshrc` merged from base + private + org layers, with overlay hooks in `~/.zshrc.d/`
+- **Git** — `~/.gitconfig` with `[include]` directives to per-org configs in `~/.gitconfig.d/`
+- **macOS defaults** — Dock, Finder, keyboard, trackpad, screenshot settings
+- **SSH** — ed25519 key pair generated and registered with GitHub
+- **Claude Code** — MCP servers and context files merged from all layers
+
+---
+
+## 4. Customizing Your Setup
+
+### How the Layer Model Works
+
+Loadout merges configuration from three layers, with later layers overriding earlier ones:
+
+```
+Priority 1 (lowest):   ~/.dotfiles/dotfiles/base/          Public base
+Priority 2:            ~/.dotfiles-private/dotfiles/base/   Private base
+Priority 3 (highest):  ~/.dotfiles-private/dotfiles/orgs/   Org overlays
+```
+
+The merge strategy depends on the file type:
+
+| File Type | Strategy |
+|---|---|
+| `.zshrc`, `.aliases`, `.zprofile`, `.zshenv` | Concatenation (layers appended with comment separators) |
+| `.gitconfig` | Include directives (`[include]` to `~/.gitconfig.d/`) |
+| `*.json` | Recursive deep merge (later layers win on conflicts) |
+| `*.yaml`, `*.yml` | Recursive deep merge |
+| Everything else | Replace (last layer wins entirely) |
+
+After making changes to any layer, run `loadout build` to regenerate the merged output.
+
+### Adding Homebrew Packages
+
+To add packages to your personal setup, create or edit a Brewfile in your private repo:
+
+```ruby
+# ~/.dotfiles-private/brewfiles/Brewfile.private
+brew "ripgrep"
+brew "fd"
+cask "obsidian"
+```
+
+For org-specific packages:
+
+```ruby
+# ~/.dotfiles-private/brewfiles/orgs/Brewfile.YOUR_ORG
+brew "awscli"
+cask "docker"
+```
+
+Then run `loadout update` to install the new packages.
+
+### Adding Shell Configuration
+
+For personal shell config that applies across all orgs, add to your private base:
+
+```bash
+# ~/.dotfiles-private/dotfiles/base/.zshrc
+# This gets concatenated after the public base .zshrc
+
+export EDITOR="nvim"
+alias ll="ls -la"
+```
+
+For org-specific shell config, add to the org overlay:
+
+```bash
+# ~/.dotfiles-private/dotfiles/orgs/YOUR_ORG/.zshrc
+export AWS_PROFILE="YOUR_ORG"
+```
+
+You can also use the overlay hooks for quick, runtime changes that do not require a rebuild:
+
+- **`~/.zshrc.d/*.zsh`** — Drop-in scripts sourced in numeric order. Use prefixes like `10-` for org config, `50-` for devbox, `90-` for private overrides.
+- **`~/.zshrc.local`** — Sourced last. Good for machine-specific overrides that should not be in version control.
+
+### Configuring Git Identity
+
+Git identity should go in your private repo so it is never committed to a public repo:
+
+```ini
+# ~/.dotfiles-private/dotfiles/orgs/YOUR_ORG/.gitconfig
+[user]
+    name = Your Name
+    email = your-email@example.com
+```
+
+For machine-specific git overrides, use `~/.gitconfig.local`:
+
+```bash
+git config --file ~/.gitconfig.local user.signingkey "YOUR_KEY_ID"
+```
+
+### Adding MCP Servers for Claude Code
+
+To add private or org-specific MCP servers for Claude Code:
+
+```json
+// ~/.dotfiles-private/claude/orgs/YOUR_ORG/mcp-YOUR_ORG.json
+{
+  "mcpServers": {
+    "your-server": {
+      "command": "your-mcp-server",
+      "args": ["--config", "/path/to/config"]
+    }
+  }
+}
+```
+
+Run `loadout build` to merge the MCP configs into `~/.claude/mcp.json`.
+
+---
+
+## 5. Day-to-Day Usage
+
+### Pull Latest and Rebuild
+
+```bash
+loadout update
+```
+
+This pulls the latest changes from your dotfiles repos, rebuilds the merged dotfiles, runs `brew bundle` to install any new packages, and installs global packages. Safe and idempotent — run it whenever you want to sync.
+
+### Upgrade Everything
+
+```bash
+loadout upgrade
+```
+
+Everything in `update` plus `brew upgrade`. Run this intentionally, since Homebrew upgrades can occasionally break things. Use `--verbose` to see what is being upgraded.
+
+### Check System Health
+
+```bash
+loadout check
+```
+
+Read-only health checks that never change anything. Reports on git status, Homebrew state, stale sessions, and disk space. Warnings are informational (optional tools not installed); errors indicate required tools that are missing.
+
+### Rebuild Dotfiles
+
+```bash
+loadout build
+```
+
+Merges base + private + org layers and writes the result to `~/`. Use this after editing dotfile sources in either repo. Use `--dry-run` to preview changes without applying them.
+
+### Manage Display Settings
+
+```bash
+loadout display              # Auto-detect connected displays
+loadout display connected    # Force desktop/connected mode
+loadout display solo         # Force laptop-solo mode
+```
+
+Applies power management and display settings based on your hardware configuration. Only relevant on macOS.
+
+---
+
+## 6. Advanced Topics
+
+### Multi-Org Support
+
+Loadout supports multiple organizations simultaneously. Each org gets its own:
+
+- Git identity (conditional includes based on directory)
+- Homebrew packages
+- Shell environment variables
+- Claude Code MCP servers and context
+- iTerm2 color-coded terminal profiles
+
+Configure active orgs during init or update `.loadout.toml` directly:
+
+```toml
+user = "YOUR_USERNAME"
+orgs = ["personal", "work"]
+```
+
+Org overlays are applied in order, with later orgs taking priority on conflicts.
+
+### Dev Environments with Devbox
+
+[Devbox](https://github.com/oakensoul/devbox) creates disposable, SSH-only macOS user accounts for project isolation. Each devbox is a separate macOS user with its own home directory, SSH key, and shell environment.
+
+```bash
+devbox create --name myproject --org YOUR_ORG
+ssh dx-myproject@localhost
+```
+
+Devbox reads presets from your `dotfiles-private` repo to configure environments per org.
+
+### Project Workspaces with Canvas
+
+[Canvas](https://github.com/oakensoul/canvas) manages ephemeral Claude Code workspaces. Each canvas session gets a dated directory with org-specific context injected from Jinja2 templates.
+
+```bash
+canvas new --org YOUR_ORG --name "api refactor"
+canvas list
+canvas archive SESSION_SLUG
+```
+
+### Manual Bootstrap
+
+If you prefer not to use the loadout CLI, you can run the bootstrap scripts directly:
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+
+# Step 1: Install base tools
+./bootstrap/install-base.sh
+# Installs: Xcode CLI tools, Homebrew, Brewfile.base packages,
+# global runtimes (nvm, Node.js, pyenv, Python), macOS defaults
+
+# Step 2: Install dotfiles
+./bootstrap/install-user.sh
+# Backs up existing dotfiles to ~/.loadout/backups/,
+# copies base configs to ~/, creates overlay directories
+
+# Step 3 (optional): Install developer tools
+./bootstrap/install-devbox.sh
+# Installs: Brewfile.devbox packages, dev runtimes,
+# devbox shell overlay, display detection
+```
+
+After running the manual scripts, set up your git identity:
+
+```bash
+git config --file ~/.gitconfig.local user.name "Your Name"
+git config --file ~/.gitconfig.local user.email "your-email@example.com"
+```
+
+Note that the manual scripts only install the base layer. They do not merge private or org layers, which is what `loadout init` and `loadout build` handle.
+
+---
+
+## 7. Troubleshooting
+
+For any issue, start by running with `--verbose` to see the exact commands being executed:
+
+```bash
+loadout check --verbose
+```
+
+### Xcode CLI Tools Installation Hangs
+
+The Xcode CLI tools installer sometimes stalls waiting for user input in a background dialog. Check for a macOS dialog box asking you to agree to the license terms. If the install is truly stuck, cancel it and install manually:
+
+```bash
+xcode-select --install
+```
+
+Then wait for the macOS installer dialog to complete.
+
+### Homebrew Permission Issues
+
+If `brew bundle` fails with permission errors, try:
+
+```bash
+sudo chown -R "$(whoami)" /opt/homebrew
+brew doctor
+```
+
+On Intel Macs, the Homebrew prefix is `/usr/local/Homebrew` instead.
+
+### SSH Key Registration Fails
+
+SSH key registration requires both the 1Password CLI (`op`) and the GitHub CLI (`gh`). If either is missing, `loadout init` will skip this step with a warning. To register manually:
+
+```bash
+# Copy your public key
+cat ~/.ssh/id_ed25519.pub | pbcopy
+
+# Add it on GitHub: Settings > SSH and GPG keys > New SSH key
+```
+
+### 1Password CLI Not Found
+
+Install the 1Password CLI via Homebrew:
+
+```bash
+brew install --cask 1password-cli
+```
+
+You also need to enable CLI integration in the 1Password desktop app: Settings > Developer > Command-Line Interface.
+
+### Loadout Check Warnings
+
+Warnings from `loadout check` are informational. They indicate optional tools that are not installed. Only errors indicate required tools that are missing and need attention.
+
+### Git Pull Fails During Update
+
+`loadout update` uses `--ff-only` for safety when pulling. If you have local uncommitted changes in your dotfiles repos:
+
+```bash
+cd ~/.dotfiles
+git stash       # or git commit
+loadout update
+```
+
+### Build Fails With Malformed JSON/YAML
+
+Check the file path in the error message. The org overlay file has a syntax error. Fix the file in your private repo and re-run:
+
+```bash
+loadout build
+```
+
+### How to Start Over
+
+If things go wrong and you want a clean slate:
+
+```bash
+# Remove loadout-managed directories
+rm -rf ~/.dotfiles ~/.dotfiles-private ~/.loadout ~/.dotfiles/build
+
+# Restore backed-up dotfiles (if any)
+ls ~/.dotfiles/backups/      # or ~/.loadout/backups/
+# Copy desired backup files back to ~/
+
+# Re-run init
+loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
+```
+
+### Where to Get Help
+
+- Open an issue on [oakensoul/dotfiles](https://github.com/oakensoul/dotfiles/issues) for base layer issues
+- Open an issue on [oakensoul/loadout](https://github.com/oakensoul/loadout/issues) for CLI tool issues
+
+---
+
+## 8. Uninstalling
+
+To remove Loadout and restore your original dotfiles:
+
+### Step 1: Restore Original Dotfiles
+
+If you had dotfiles before installing Loadout, they were backed up:
+
+```bash
+# Check for backups
+ls ~/.dotfiles/backups/
+ls ~/.loadout/backups/
+
+# Copy the most recent backup back to ~/
+cp ~/.loadout/backups/TIMESTAMP/.zshrc ~/
+cp ~/.loadout/backups/TIMESTAMP/.gitconfig ~/
+cp ~/.loadout/backups/TIMESTAMP/.aliases ~/
+```
+
+If you did not have previous dotfiles, you can simply delete the installed ones:
+
+```bash
+rm ~/.zshrc ~/.gitconfig ~/.aliases
+```
+
+### Step 2: Remove Overlay Directories
+
+```bash
+rm -rf ~/.zshrc.d
+rm -rf ~/.gitconfig.d
+rm -f ~/.zshrc.local
+rm -f ~/.gitconfig.local
+```
+
+### Step 3: Remove Loadout State
+
+```bash
+rm -rf ~/.dotfiles
+rm -rf ~/.dotfiles-private
+rm -rf ~/.loadout
+```
+
+### Step 4: Remove Claude Code Config (Optional)
+
+```bash
+rm -rf ~/.claude
+```
+
+### Step 5: Uninstall the CLI
+
+```bash
+pip3 uninstall oakensoul-loadout
+```
+
+Homebrew packages, nvm, pyenv, and other installed tools will remain on your system. Remove them individually if desired:
+
+```bash
+# Remove nvm
+rm -rf ~/.nvm
+
+# Remove pyenv
+brew uninstall pyenv
+
+# Remove all Homebrew packages (nuclear option)
+# brew list | xargs brew uninstall --force
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -23,7 +23,7 @@ A step-by-step guide to setting up your macOS machine with the Loadout configura
 
 Loadout takes a fresh macOS machine from factory settings to a fully configured development environment in a single command. It installs your tools, applies your shell and git configuration, sets macOS preferences, and manages updates going forward.
 
-Unlike traditional dotfile managers that symlink files from a single repo, Loadout uses a **layered merge system**. You maintain a public base layer (this repo) with sensible defaults, then overlay private and organization-specific configuration on top. This means you can share your base setup publicly without exposing personal details, and switch between different team contexts cleanly.
+Unlike traditional dotfile managers that symlink files from a single repo, Loadout uses a **layered merge system**. You maintain a public base layer (this repo) with sensible defaults, then overlay private and organization-specific configuration on top. This means you can share your base setup publicly without exposing personal details, and switch between different team contexts cleanly. For a deeper look at the system design, see the [Architecture documentation](architecture/README.md).
 
 ### Prerequisites Checklist
 
@@ -172,7 +172,7 @@ After `loadout init` completes, here is what was created and configured on your 
 - **Homebrew packages** from `Brewfile.base` plus any org-specific Brewfiles
 - **Node.js** via nvm (latest LTS)
 - **Python** via pyenv
-- **Claude Code** (global npm package)
+- **Claude Code** (installed via curl)
 - Any additional global packages defined in your org globals scripts
 
 ### What Got Configured

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -43,18 +43,18 @@ You have two options for getting started:
 
 ### What Will Happen
 
-When you run `loadout init`, the CLI performs a 12-step bootstrap:
+When you run `loadout init`, the CLI performs a 13-step bootstrap:
 
 1. Ensure Xcode Command Line Tools are installed
-2. Clone your dotfiles repo (this repo) to `~/.dotfiles`
-3. Clone your dotfiles-private repo to `~/.dotfiles-private`
-4. Generate an SSH key pair
-5. Register the SSH key with GitHub (using 1Password for the passphrase)
-6. Switch git remotes from HTTPS to SSH
-7. Build dotfiles (merge base + private + org layers into `~/`)
-8. Run Homebrew bundle (install all packages from assembled Brewfiles)
-9. Install global runtimes (Node.js via nvm, Python via pyenv, Claude Code)
-10. Build Claude Code configuration (merge MCP configs and CLAUDE.md)
+2. Clone dotfiles repos (both `dotfiles` and `dotfiles-private`)
+3. Generate an SSH key pair (with an empty passphrase)
+4. Register the SSH key with GitHub (using 1Password for a GitHub API token)
+5. Switch git remotes from HTTPS to SSH
+6. Build dotfiles (merge base + private + org layers into `~/`)
+7. Run Homebrew bundle (install all packages from assembled Brewfiles)
+8. Install global runtimes (Node.js via nvm, Python via pyenv, Claude Code)
+9. Build Claude Code configuration (merge MCP configs and CLAUDE.md)
+10. Bootstrap canvas configuration (`~/.canvas/config.json`)
 11. Apply macOS system defaults (Dock, Finder, keyboard, trackpad, screenshots)
 12. Set up display launch agent (auto-detect connected displays and apply power settings)
 13. Save configuration to `~/.dotfiles/.loadout.toml`
@@ -69,7 +69,11 @@ On GitHub, fork this repository to your own account. If you plan to customize th
 
 ### Step 2: Create Your Private Repo
 
-Create a private repository called `dotfiles-private` in your GitHub account. This will hold your personal identity, org-specific configs, and secrets references. The expected structure is:
+Create a private repository called `dotfiles-private` in your GitHub account. This will hold your personal identity, org-specific configs, and secrets references.
+
+> **Note:** If you skip this step, `loadout init` will fail when it tries to clone the missing `dotfiles-private` repo. Either create an empty private repo on GitHub before running init, or use the [manual bootstrap](#manual-bootstrap) approach which only requires the public base layer. You can always create the private repo later and run `loadout build` to merge it in.
+
+The expected structure is:
 
 ```
 dotfiles-private/
@@ -107,8 +111,11 @@ Follow the post-install instructions to add Homebrew to your PATH.
 
 ### Step 4: Install the Loadout CLI
 
+Loadout is not yet published to PyPI. Install it from the GitHub repository:
+
 ```bash
-pip3 install oakensoul-loadout
+git clone https://github.com/oakensoul/loadout.git ~/.loadout-cli
+pip3 install ~/.loadout-cli
 ```
 
 Verify the installation:
@@ -173,6 +180,7 @@ After `loadout init` completes, here is what was created and configured on your 
 - **Node.js** via nvm (latest LTS)
 - **Python** via pyenv
 - **Claude Code** (installed via curl)
+- **Canvas config** at `~/.canvas/config.json` (if canvas is installed and orgs are configured)
 - Any additional global packages defined in your org globals scripts
 
 ### What Got Configured
@@ -385,8 +393,8 @@ If you prefer not to use the loadout CLI, you can run the bootstrap scripts dire
 
 ```bash
 # Clone your fork
-git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/dotfiles
-cd ~/dotfiles
+git clone https://github.com/YOUR_USERNAME/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
 
 # Step 1: Install base tools
 ./bootstrap/install-base.sh
@@ -492,14 +500,15 @@ loadout build
 If things go wrong and you want a clean slate:
 
 ```bash
-# Remove loadout-managed directories
-rm -rf ~/.dotfiles ~/.dotfiles-private ~/.loadout ~/.dotfiles/build
-
-# Restore backed-up dotfiles (if any)
-ls ~/.dotfiles/backups/      # or ~/.loadout/backups/
+# 1. Restore backed-up dotfiles BEFORE deleting anything.
+#    Backups are stored in ~/.loadout/backups/ (the canonical location).
+ls ~/.loadout/backups/
 # Copy desired backup files back to ~/
 
-# Re-run init
+# 2. Remove loadout-managed directories
+rm -rf ~/.dotfiles ~/.dotfiles-private ~/.loadout
+
+# 3. Re-run init
 loadout init --user=YOUR_USERNAME --orgs=YOUR_ORG
 ```
 
@@ -562,6 +571,7 @@ rm -rf ~/.claude
 
 ```bash
 pip3 uninstall oakensoul-loadout
+rm -rf ~/.loadout-cli
 ```
 
 Homebrew packages, nvm, pyenv, and other installed tools will remain on your system. Remove them individually if desired:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,426 @@
+# Loadout Ecosystem Architecture
+
+> C4 architecture documentation for the Loadout multi-repo macOS machine configuration system.
+>
+> Version: 0.1.0 | Last updated: 2026-03-30
+
+---
+
+## Table of Contents
+
+1. [System Context (C4 Level 1)](#1-system-context-c4-level-1)
+2. [Container Diagram (C4 Level 2)](#2-container-diagram-c4-level-2)
+3. [Component Diagram (C4 Level 3)](#3-component-diagram-c4-level-3)
+4. [Data Flow Diagrams](#4-data-flow-diagrams)
+5. [Merge Strategy Details](#5-merge-strategy-details)
+6. [State and Storage](#6-state-and-storage)
+7. [Multi-Org Model](#7-multi-org-model)
+8. [Glossary](#8-glossary)
+
+---
+
+## 1. System Context (C4 Level 1)
+
+The Loadout system configures and maintains macOS development machines. It interacts with several external systems to install software, manage secrets, provide visual identity, and enable AI-assisted development.
+
+```mermaid
+C4Context
+    title Loadout System Context
+
+    Person(dev, "Developer", "macOS user who develops software across multiple orgs")
+
+    System(loadout, "Loadout Ecosystem", "Multi-repo machine config system: CLI orchestrator, config layers, devbox environments, Claude Code workspaces")
+
+    System_Ext(github, "GitHub", "Git hosting, SSH key registration, PR workflows")
+    System_Ext(onepassword, "1Password", "Secret storage, SSH agent, op:// URI resolution")
+    System_Ext(homebrew, "Homebrew", "macOS package manager, cask installer, bundle files")
+    System_Ext(macos, "macOS", "System defaults, user accounts (dscl), power management (pmset), launch agents")
+    System_Ext(iterm2, "iTerm2", "Terminal emulator with dynamic profiles, color-coded per org")
+    System_Ext(claude, "Claude Code", "AI coding assistant, MCP servers, CLAUDE.md context, API providers")
+    System_Ext(nvm, "nvm / pyenv", "Node.js and Python version managers")
+
+    Rel(dev, loadout, "Runs CLI commands")
+    Rel(loadout, github, "Clones repos, registers SSH keys, manages remotes")
+    Rel(loadout, onepassword, "Reads secrets via op CLI")
+    Rel(loadout, homebrew, "Installs packages via brew bundle")
+    Rel(loadout, macos, "Applies system defaults, manages users, configures power")
+    Rel(loadout, iterm2, "Generates dynamic profiles")
+    Rel(loadout, claude, "Builds config: mcp.json, CLAUDE.md, provider scripts")
+    Rel(loadout, nvm, "Installs Node.js / Python runtimes and global packages")
+```
+
+---
+
+## 2. Container Diagram (C4 Level 2)
+
+The ecosystem spans five repositories. Three are Python CLIs (loadout, devbox, canvas) and two are configuration repositories (dotfiles, dotfiles-private). The loadout CLI orchestrates everything; devbox and canvas are specialized tools that share infrastructure.
+
+```mermaid
+C4Container
+    title Loadout Ecosystem — Containers
+
+    Person(dev, "Developer")
+
+    System_Boundary(ecosystem, "Loadout Ecosystem") {
+        Container(loadout_cli, "loadout", "Python 3.11+, Click, Rich", "Orchestrator CLI: init, build, update, upgrade, check, globals, display")
+        Container(devbox_cli, "devbox", "Python 3.11+, Click, Pydantic v2, Rich", "Disposable dev environment CLI: create, list, nuke, rebuild")
+        Container(canvas_cli, "canvas", "Python 3.11+, Click, Rich, Jinja2", "Claude Code session manager: new, list, show, archive, nuke")
+        ContainerDb(dotfiles, "dotfiles", "Git repo at ~/.dotfiles", "Public base layer: shell config, Brewfiles, bootstrap scripts, Claude templates")
+        ContainerDb(dotfiles_priv, "dotfiles-private", "Git repo at ~/.dotfiles-private", "Private org layer: per-org secrets (op://), git identity, Claude config, devbox presets, canvas templates")
+    }
+
+    System_Ext(github, "GitHub")
+    System_Ext(onepassword, "1Password")
+    System_Ext(homebrew, "Homebrew")
+    System_Ext(macos, "macOS")
+    System_Ext(iterm2, "iTerm2")
+    System_Ext(claude, "Claude Code")
+
+    Rel(dev, loadout_cli, "loadout init / build / update / upgrade")
+    Rel(dev, devbox_cli, "devbox create / nuke")
+    Rel(dev, canvas_cli, "canvas new / list / archive")
+
+    Rel(loadout_cli, dotfiles, "Clones, reads base config")
+    Rel(loadout_cli, dotfiles_priv, "Clones, reads org config")
+    Rel(loadout_cli, homebrew, "brew bundle")
+    Rel(loadout_cli, macos, "defaults write, pmset")
+    Rel(loadout_cli, github, "git clone, gh ssh-key add")
+    Rel(loadout_cli, onepassword, "op read")
+    Rel(loadout_cli, claude, "Writes mcp.json, CLAUDE.md, providers/")
+
+    Rel(devbox_cli, dotfiles_priv, "Reads devbox presets")
+    Rel(devbox_cli, macos, "dscl (user accounts)")
+    Rel(devbox_cli, onepassword, "Resolves op:// secrets")
+    Rel(devbox_cli, github, "Registers SSH keys")
+    Rel(devbox_cli, iterm2, "Creates per-devbox profiles")
+
+    Rel(canvas_cli, dotfiles_priv, "Reads Jinja2 templates from canvas/orgs/")
+    Rel(canvas_cli, claude, "Launches Claude Code in session dir")
+    Rel(canvas_cli, iterm2, "Uses per-org iTerm2 profiles")
+```
+
+### Container Summary
+
+| Container | Repo | Type | Version | Key Responsibility |
+|---|---|---|---|---|
+| **loadout** | `oakensoul/loadout` | Python CLI | v0.1.0 Beta | Machine bootstrap and ongoing maintenance |
+| **dotfiles** | `oakensoul/dotfiles` (this repo) | Config repo | n/a | Public base layer — universal macOS defaults |
+| **dotfiles-private** | `oakensoul/dotfiles-private` | Config repo | n/a | Private org layer — secrets, identity, overrides |
+| **devbox** | `oakensoul/devbox` | Python CLI | v0.1.0 Alpha | Disposable SSH-only dev environments |
+| **canvas** | `oakensoul/canvas` | Python CLI | v0.1.0 Alpha | Ephemeral Claude Code workspaces |
+
+---
+
+## 3. Component Diagram (C4 Level 3)
+
+Internal architecture of the **loadout** orchestrator CLI.
+
+```mermaid
+C4Component
+    title loadout CLI — Components
+
+    Container_Boundary(loadout, "loadout CLI") {
+        Component(cli, "CLI Layer", "Click", "Command routing: init, build, update, upgrade, check, globals, display")
+        Component(init, "Init Module", "Python", "12-step bootstrap: Xcode, clone, SSH, brew, globals, claude, macos")
+        Component(build, "Build Module", "Python", "Three-layer merge pipeline: concat, include, deep merge, replace")
+        Component(brew, "Brew Module", "Python", "Homebrew bundle: aggregate Brewfiles, run brew bundle")
+        Component(globals, "Globals Module", "Python", "Runtime installers: nvm, pyenv, npm globals, pip globals")
+        Component(claude_mod, "Claude Module", "Python", "Build Claude config: mcp.json, CLAUDE.md, API provider scripts")
+        Component(check, "Check Module", "Python", "Health probes: git status, brew doctor, stale sessions, disk space")
+        Component(display, "Display Module", "Python", "Power profiles: pmset config per hardware, launch agent for display watch")
+        Component(macos_mod, "macOS Module", "Python", "System defaults: Dock, Finder, keyboard, trackpad, screenshots")
+        Component(core, "core.py", "Python", "Stable public API for AIDA plugin integration")
+        Component(config, "Config", "TOML", "~/.dotfiles/.loadout.toml — user, orgs, versions, paths")
+    }
+
+    Rel(cli, init, "loadout init")
+    Rel(cli, build, "loadout build")
+    Rel(cli, brew, "loadout brew / update")
+    Rel(cli, globals, "loadout globals")
+    Rel(cli, claude_mod, "loadout build / init")
+    Rel(cli, check, "loadout check")
+    Rel(cli, display, "loadout display")
+    Rel(cli, macos_mod, "loadout init")
+    Rel(cli, core, "Delegates operations")
+    Rel(init, build, "Step 7: merge dotfiles")
+    Rel(init, brew, "Step 8: brew bundle")
+    Rel(init, globals, "Step 9: install runtimes")
+    Rel(init, claude_mod, "Step 10: build Claude config")
+    Rel(init, macos_mod, "Step 11: apply defaults")
+    Rel(init, display, "Step 12: launch agent")
+    Rel(build, config, "Reads merge rules, org list")
+```
+
+---
+
+## 4. Data Flow Diagrams
+
+### 4.1 loadout init (Bootstrap Flow)
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant LO as loadout CLI
+    participant macOS as macOS
+    participant GH as GitHub
+    participant OP as 1Password
+    participant HB as Homebrew
+    participant NVM as nvm / pyenv
+    participant CC as Claude Code
+
+    Dev->>LO: loadout init
+    Note over LO: Step 1
+    LO->>macOS: Ensure Xcode CLI Tools (xcode-select --install)
+
+    Note over LO: Step 2
+    LO->>GH: git clone oakensoul/dotfiles → ~/.dotfiles
+
+    Note over LO: Step 3
+    LO->>GH: git clone oakensoul/dotfiles-private → ~/.dotfiles-private
+
+    Note over LO: Step 4
+    LO->>macOS: ssh-keygen -t ed25519
+
+    Note over LO: Step 5
+    LO->>OP: op read (SSH passphrase)
+    LO->>GH: gh ssh-key add
+
+    Note over LO: Step 6
+    LO->>GH: Switch remotes HTTPS → SSH
+
+    Note over LO: Step 7
+    LO->>LO: Build dotfiles (three-layer merge → ~/)
+
+    Note over LO: Step 8
+    LO->>HB: brew bundle (aggregated Brewfiles)
+
+    Note over LO: Step 9
+    LO->>NVM: Install Node.js, Python, npm globals, pip globals
+
+    Note over LO: Step 10
+    LO->>CC: Write mcp.json, CLAUDE.md, provider scripts → ~/.claude/
+
+    Note over LO: Step 11
+    LO->>macOS: defaults write (Dock, Finder, keyboard, trackpad, screenshots)
+
+    Note over LO: Step 12
+    LO->>macOS: Install display-watch launch agent (pmset)
+```
+
+### 4.2 loadout build (Merge Pipeline)
+
+```mermaid
+sequenceDiagram
+    participant LO as loadout CLI
+    participant Base as ~/.dotfiles/dotfiles/base/
+    participant PrivBase as ~/.dotfiles-private/dotfiles/base/
+    participant Org as ~/.dotfiles-private/dotfiles/orgs/{org}/
+    participant Build as ~/.dotfiles/build/
+    participant Home as ~/
+
+    LO->>LO: Read .loadout.toml (active orgs, merge rules)
+
+    LO->>Base: Read public base files
+    LO->>PrivBase: Read private base files (optional)
+    LO->>Org: Read org overlay files (per active org)
+
+    Note over LO: Per-file merge strategy
+    LO->>LO: .zshrc, .aliases → concatenate layers (separator comments)
+    LO->>LO: .gitconfig → generate [include] directives
+    LO->>LO: *.json → recursive deep merge (jq)
+    LO->>LO: *.yaml → recursive deep merge
+    LO->>LO: other files → last layer wins (replace)
+
+    LO->>Build: Write merged output (atomic staging)
+    LO->>Home: Backup existing files → ~/.dotfiles/backups/
+    LO->>Home: Copy merged files to ~/
+    LO->>Home: Write ~/.zshrc.d/*.zsh overlay files
+    LO->>Home: Write ~/.gitconfig.d/ include files
+```
+
+### 4.3 devbox create (Environment Provisioning)
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant DB as devbox CLI
+    participant OP as 1Password
+    participant macOS as macOS
+    participant GH as GitHub
+    participant IT as iTerm2
+    participant Priv as dotfiles-private
+
+    Dev->>DB: devbox create --name myproject --org splash
+    DB->>Priv: Load preset from devbox/presets/
+
+    Note over DB: Compensation stack initialized (rollback on failure)
+
+    DB->>macOS: dscl — create user dx-myproject
+    DB->>macOS: Create home directory, set permissions
+
+    DB->>macOS: ssh-keygen -t ed25519 (for dx-myproject)
+    DB->>OP: op read (SSH passphrase)
+    DB->>GH: gh ssh-key add (register devbox SSH key)
+
+    DB->>DB: Apply preset config (shell, git, packages)
+    DB->>IT: Generate iTerm2 dynamic profile for dx-myproject
+
+    DB->>DB: Write heartbeat file (atrophy detection)
+    DB->>DB: Register in ~/.devbox/registry.json
+
+    DB-->>Dev: Devbox dx-myproject ready (SSH: ssh dx-myproject@localhost)
+```
+
+### 4.4 canvas new (Session Creation)
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant CV as canvas CLI
+    participant Priv as dotfiles-private
+    participant FS as Filesystem
+    participant CC as Claude Code
+    participant IT as iTerm2
+
+    Dev->>CV: canvas new --org splash --name "api refactor"
+
+    CV->>CV: Generate slug: 2026-03-30-azure-falcon
+    CV->>FS: mkdir ~/.canvas/sessions/2026-03-30-azure-falcon/
+
+    CV->>Priv: Load Jinja2 template from canvas/orgs/splash/CLAUDE.md.tmpl
+    CV->>CV: Render CLAUDE.md with org context injection
+    CV->>FS: Write CLAUDE.md to session directory
+
+    CV->>FS: Update ~/.canvas/registry.json (add session entry)
+
+    CV->>IT: Open in org-specific iTerm2 profile (splash color scheme)
+    CV->>CC: Launch Claude Code in session directory
+
+    CV-->>Dev: Session ready: ~/.canvas/sessions/2026-03-30-azure-falcon/
+```
+
+---
+
+## 5. Merge Strategy Details
+
+The `loadout build` command merges dotfiles from three layers in priority order. Later layers override earlier ones.
+
+### Layer Priority (lowest to highest)
+
+| Priority | Layer | Source Path |
+|---|---|---|
+| 1 (base) | Public base | `~/.dotfiles/dotfiles/base/` |
+| 2 | Private base | `~/.dotfiles-private/dotfiles/base/` |
+| 3 (highest) | Org overlays | `~/.dotfiles-private/dotfiles/orgs/{org}/` |
+
+### Merge Strategy by File Type
+
+| File Pattern | Strategy | Behavior |
+|---|---|---|
+| `.zshrc` | Concatenation | Layers appended sequentially, separated by comment markers (`# --- layer: base ---`) |
+| `.aliases` | Concatenation | Same as `.zshrc` — all aliases from all layers combined |
+| `.zprofile` | Concatenation | Same as `.zshrc` |
+| `.zshenv` | Concatenation | Same as `.zshrc` |
+| `.gitconfig` | Include directives | Each layer written to `~/.gitconfig.d/{layer}.gitconfig`; root `.gitconfig` uses `[include]` to load them in order |
+| `*.json` | Recursive deep merge | Objects merged recursively; arrays replaced; later layers win on key conflicts |
+| `*.yaml`, `*.yml` | Recursive deep merge | Same as JSON — recursive object merge, later layers win |
+| All other files | Replace | Last layer providing the file wins entirely |
+
+### Overlay Hook System
+
+Beyond the merge pipeline, Loadout installs overlay hooks that allow runtime customization without rebuilding:
+
+| Hook | Location | Purpose |
+|---|---|---|
+| `~/.zshrc.d/*.zsh` | Numeric-prefix ordered | `10-*` org config, `50-*` devbox, `90-*` private overrides |
+| `~/.gitconfig.d/` | Include-loaded | Per-org git configs with conditional includes |
+| `~/.zshrc.local` | Sourced last | Machine-specific shell overrides (not managed by loadout) |
+| `~/.gitconfig.local` | Included last | Machine-specific git overrides (not managed by loadout) |
+
+---
+
+## 6. State and Storage
+
+Each tool maintains its own state directory. There are no shared databases — tools communicate through the filesystem and well-known paths.
+
+| Path | Owner | Contents |
+|---|---|---|
+| `~/.dotfiles/` | loadout (git) | Public base config repo (this repo) |
+| `~/.dotfiles-private/` | loadout (git) | Private org config repo |
+| `~/.dotfiles/.loadout.toml` | loadout | Primary config: user identity, active orgs, tool versions, paths |
+| `~/.dotfiles/build/` | loadout | Merged build output (staging area before copy to `~/`) |
+| `~/.dotfiles/backups/` | loadout | Timestamped backups of files before overwrite |
+| `~/.loadout/` | loadout | Runtime state: `logs/`, `backups/`, timestamps, future `manifest.json` |
+| `~/.devbox/` | devbox | `config.json`, `registry.json` (devbox inventory and settings) |
+| `~/.canvas/` | canvas | `config`, `registry.json` (session inventory), `sessions/` (workspace dirs) |
+| `~/.claude/` | loadout / canvas | `mcp.json`, `CLAUDE.md`, `providers/` (API key scripts) |
+| `~/Library/Application Support/iTerm2/DynamicProfiles/` | loadout / devbox / canvas | Generated iTerm2 dynamic profile JSON files |
+
+### State Ownership Rules
+
+- **loadout** is the sole writer of `~/.dotfiles/`, `~/.dotfiles-private/`, and merged output in `~/`.
+- **devbox** manages macOS user accounts and `~/.devbox/` state. It reads presets from `~/.dotfiles-private/` but never writes to it.
+- **canvas** manages `~/.canvas/` state. It reads Jinja2 templates from `~/.dotfiles-private/` but never writes to it.
+- **loadout check** reads state from all three tools to report health.
+
+---
+
+## 7. Multi-Org Model
+
+Loadout supports five organizations, each receiving isolated configuration across every tool.
+
+### Supported Organizations
+
+| Org Slug | Purpose |
+|---|---|
+| `personal` | Personal projects and default identity |
+| `splash` | Primary employer |
+| `mythical-journeys` | Side project |
+| `sidequest-syndicate` | Side project collective |
+| `equinox-consulting` | Consulting work |
+
+### Per-Org Configuration Surface
+
+| Concern | Mechanism | Location |
+|---|---|---|
+| **Git identity** | Conditional includes in `.gitconfig` | `~/.gitconfig.d/{org}.gitconfig` |
+| **Shell globals** | Sourced via `~/.zshrc.d/10-{org}.zsh` | `dotfiles-private/globals/orgs/{org}/` |
+| **Brewfile extensions** | Aggregated by `loadout brew` | `dotfiles-private/brewfiles/orgs/{org}/Brewfile` |
+| **Claude Code config** | Per-org `CLAUDE.md`, MCP servers, API providers | `dotfiles-private/claude/orgs/{org}/` |
+| **Devbox presets** | Preset JSON loaded by `devbox create --org` | `dotfiles-private/devbox/presets/{org}/` |
+| **Canvas templates** | Jinja2 `CLAUDE.md.tmpl` rendered per session | `dotfiles-private/canvas/orgs/{org}/CLAUDE.md.tmpl` |
+| **iTerm2 profiles** | Color-coded dynamic profiles per org | Generated at runtime; colors identify org visually |
+| **Secrets** | `op://` references scoped per org vault | `dotfiles-private/globals/orgs/{org}/` |
+
+### Org Resolution
+
+1. `loadout init` prompts for active orgs, writes to `.loadout.toml`.
+2. `loadout build` iterates active orgs, merging their overlays in order.
+3. `devbox create --org <slug>` loads the matching preset.
+4. `canvas new --org <slug>` selects the matching Jinja2 template and iTerm2 profile.
+
+---
+
+## 8. Glossary
+
+| Term | Definition |
+|---|---|
+| **Base layer** | The public `dotfiles` repo containing universal macOS defaults. First (lowest priority) merge layer. |
+| **Org layer** | Per-organization configuration in `dotfiles-private`. Overrides the base layer. |
+| **Private layer** | The combination of `dotfiles-private/dotfiles/base/` and org overlays. Higher priority than public base. |
+| **Overlay hook** | A well-known file path (`~/.zshrc.d/`, `~/.gitconfig.d/`, `~/.zshrc.local`) that allows runtime customization without rebuilding. |
+| **Three-layer merge** | The build pipeline that combines public base, private base, and org overlays into final dotfiles. |
+| **Loadout** | Both the ecosystem name and the orchestrator CLI (`oakensoul/loadout`). |
+| **Devbox** | A disposable SSH-only macOS user account (prefixed `dx-`) for project-scoped development. |
+| **Canvas** | An ephemeral Claude Code workspace — a dated directory with rendered context and session tracking. |
+| **Slug** | A human-friendly identifier. Canvas uses `YYYY-MM-DD-adjective-noun` format. |
+| **Preset** | A JSON configuration file in `dotfiles-private` that defines a devbox environment (packages, shell config, git identity). |
+| **Provider script** | A shell script in `~/.claude/providers/` that outputs a Claude Code API key, typically via `op read`. |
+| **Compensation stack** | Devbox's rollback mechanism — records each provisioning step so partial failures can be cleanly reversed. |
+| **Heartbeat file** | A timestamp file in a devbox home directory, updated on activity. Used for atrophy detection (stale devbox cleanup). |
+| **Atrophy detection** | Health check that identifies devbox environments with no recent activity, candidates for `devbox nuke`. |
+| **`op://` URI** | A 1Password CLI reference (e.g., `op://vault/item/field`) resolved at runtime by `op read`. No secrets are stored in config files. |
+| **Dynamic profile** | An iTerm2 feature where JSON files in `~/Library/Application Support/iTerm2/DynamicProfiles/` are auto-loaded as terminal profiles. |
+| **AIDA** | A future plugin system. All three Python CLIs expose `core.py` stable APIs for AIDA integration. |
+| **`loadout check`** | Health probe command that inspects git status, brew state, stale canvas sessions, devbox heartbeats, and disk space. |
+| **Atomic swap** | The build module writes merged output to a staging directory (`~/.dotfiles/build/`) then copies to `~/`, minimizing the window of inconsistent state. |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,7 +2,9 @@
 
 > C4 architecture documentation for the Loadout multi-repo macOS machine configuration system.
 >
-> Version: 0.1.0 | Last updated: 2026-03-30
+> Version: 0.1.0 | Last updated: 2026-03-31
+>
+> For getting started, see the [Setup Guide](../SETUP.md).
 
 ---
 
@@ -121,14 +123,14 @@ C4Component
 
     Container_Boundary(loadout, "loadout CLI") {
         Component(cli, "CLI Layer", "Click", "Command routing: init, build, update, upgrade, check, globals, display")
-        Component(init, "Init Module", "Python", "12-step bootstrap: Xcode, clone, SSH, brew, globals, claude, macos")
+        Component(init, "Init Module", "Python", "12-step bootstrap: Xcode, clone, SSH, brew, globals, claude, macos, canvas config")
         Component(build, "Build Module", "Python", "Three-layer merge pipeline: concat, include, deep merge, replace")
         Component(brew, "Brew Module", "Python", "Homebrew bundle: aggregate Brewfiles, run brew bundle")
-        Component(globals, "Globals Module", "Python", "Runtime installers: nvm, pyenv, npm globals, pip globals")
+        Component(globals, "Globals Module", "Python", "Runtime installers: nvm, pyenv, Claude Code (curl), npm globals, pip globals")
         Component(claude_mod, "Claude Module", "Python", "Build Claude config: mcp.json, CLAUDE.md, API provider scripts")
         Component(check, "Check Module", "Python", "Health probes: git status, brew doctor, stale sessions, disk space")
         Component(display, "Display Module", "Python", "Power profiles: pmset config per hardware, launch agent for display watch")
-        Component(macos_mod, "macOS Module", "Python", "System defaults: Dock, Finder, keyboard, trackpad, screenshots")
+        Component(macos_mod, "macOS Module", "Python", "System defaults: Dock, Finder, keyboard, trackpad, screenshots, private defaults")
         Component(core, "core.py", "Python", "Stable public API for AIDA plugin integration")
         Component(config, "Config", "TOML", "~/.dotfiles/.loadout.toml — user, orgs, versions, paths")
     }
@@ -195,13 +197,13 @@ sequenceDiagram
     LO->>HB: brew bundle (aggregated Brewfiles)
 
     Note over LO: Step 9
-    LO->>NVM: Install Node.js, Python, npm globals, pip globals
+    LO->>NVM: Install Node.js, Python, Claude Code (curl), npm globals, pip globals
 
     Note over LO: Step 10
     LO->>CC: Write mcp.json, CLAUDE.md, provider scripts → ~/.claude/
 
     Note over LO: Step 11
-    LO->>macOS: defaults write (Dock, Finder, keyboard, trackpad, screenshots)
+    LO->>macOS: defaults write (Dock, Finder, keyboard, trackpad, screenshots, private defaults)
 
     Note over LO: Step 12
     LO->>macOS: Install display-watch launch agent (pmset)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -123,7 +123,7 @@ C4Component
 
     Container_Boundary(loadout, "loadout CLI") {
         Component(cli, "CLI Layer", "Click", "Command routing: init, build, update, upgrade, check, globals, display")
-        Component(init, "Init Module", "Python", "12-step bootstrap: Xcode, clone, SSH, brew, globals, claude, macos, canvas config")
+        Component(init, "Init Module", "Python", "13-step bootstrap: Xcode, clone, SSH, brew, globals, claude, macos, canvas config")
         Component(build, "Build Module", "Python", "Three-layer merge pipeline: concat, include, deep merge, replace")
         Component(brew, "Brew Module", "Python", "Homebrew bundle: aggregate Brewfiles, run brew bundle")
         Component(globals, "Globals Module", "Python", "Runtime installers: nvm, pyenv, Claude Code (curl), npm globals, pip globals")
@@ -144,10 +144,10 @@ C4Component
     Rel(cli, display, "loadout display")
     Rel(cli, macos_mod, "loadout init")
     Rel(cli, core, "Delegates operations")
-    Rel(init, build, "Step 7: merge dotfiles")
-    Rel(init, brew, "Step 8: brew bundle")
-    Rel(init, globals, "Step 9: install runtimes")
-    Rel(init, claude_mod, "Step 10: build Claude config")
+    Rel(init, build, "Step 6: merge dotfiles")
+    Rel(init, brew, "Step 7: brew bundle")
+    Rel(init, globals, "Step 8: install runtimes")
+    Rel(init, claude_mod, "Step 9: build Claude config")
     Rel(init, macos_mod, "Step 11: apply defaults")
     Rel(init, display, "Step 12: launch agent")
     Rel(build, config, "Reads merge rules, org list")
@@ -175,38 +175,41 @@ sequenceDiagram
     LO->>macOS: Ensure Xcode CLI Tools (xcode-select --install)
 
     Note over LO: Step 2
-    LO->>GH: git clone oakensoul/dotfiles → ~/.dotfiles
+    LO->>GH: git clone dotfiles + dotfiles-private → ~/.dotfiles, ~/.dotfiles-private
 
     Note over LO: Step 3
-    LO->>GH: git clone oakensoul/dotfiles-private → ~/.dotfiles-private
+    LO->>macOS: ssh-keygen -t ed25519 (empty passphrase)
 
     Note over LO: Step 4
-    LO->>macOS: ssh-keygen -t ed25519
+    LO->>OP: op read (GitHub API token)
+    LO->>GH: gh auth login + gh ssh-key add
 
     Note over LO: Step 5
-    LO->>OP: op read (SSH passphrase)
-    LO->>GH: gh ssh-key add
-
-    Note over LO: Step 6
     LO->>GH: Switch remotes HTTPS → SSH
 
-    Note over LO: Step 7
+    Note over LO: Step 6
     LO->>LO: Build dotfiles (three-layer merge → ~/)
 
-    Note over LO: Step 8
+    Note over LO: Step 7
     LO->>HB: brew bundle (aggregated Brewfiles)
 
-    Note over LO: Step 9
+    Note over LO: Step 8
     LO->>NVM: Install Node.js, Python, Claude Code (curl), npm globals, pip globals
 
-    Note over LO: Step 10
+    Note over LO: Step 9
     LO->>CC: Write mcp.json, CLAUDE.md, provider scripts → ~/.claude/
+
+    Note over LO: Step 10
+    LO->>LO: Bootstrap canvas config → ~/.canvas/config.json
 
     Note over LO: Step 11
     LO->>macOS: defaults write (Dock, Finder, keyboard, trackpad, screenshots, private defaults)
 
     Note over LO: Step 12
     LO->>macOS: Install display-watch launch agent (pmset)
+
+    Note over LO: Step 13
+    LO->>LO: Save config → ~/.dotfiles/.loadout.toml
 ```
 
 ### 4.2 loadout build (Merge Pipeline)
@@ -252,7 +255,7 @@ sequenceDiagram
     participant IT as iTerm2
     participant Priv as dotfiles-private
 
-    Dev->>DB: devbox create --name myproject --org splash
+    Dev->>DB: devbox create --name myproject --org acme-corp
     DB->>Priv: Load preset from devbox/presets/
 
     Note over DB: Compensation stack initialized (rollback on failure)
@@ -284,18 +287,18 @@ sequenceDiagram
     participant CC as Claude Code
     participant IT as iTerm2
 
-    Dev->>CV: canvas new --org splash --name "api refactor"
+    Dev->>CV: canvas new --org acme-corp --name "api refactor"
 
     CV->>CV: Generate slug: 2026-03-30-azure-falcon
     CV->>FS: mkdir ~/.canvas/sessions/2026-03-30-azure-falcon/
 
-    CV->>Priv: Load Jinja2 template from canvas/orgs/splash/CLAUDE.md.tmpl
+    CV->>Priv: Load Jinja2 template from canvas/orgs/acme-corp/CLAUDE.md.tmpl
     CV->>CV: Render CLAUDE.md with org context injection
     CV->>FS: Write CLAUDE.md to session directory
 
     CV->>FS: Update ~/.canvas/registry.json (add session entry)
 
-    CV->>IT: Open in org-specific iTerm2 profile (splash color scheme)
+    CV->>IT: Open in org-specific iTerm2 profile (acme-corp color scheme)
     CV->>CC: Launch Claude Code in session directory
 
     CV-->>Dev: Session ready: ~/.canvas/sessions/2026-03-30-azure-falcon/
@@ -352,7 +355,7 @@ Each tool maintains its own state directory. There are no shared databases — t
 | `~/.dotfiles/.loadout.toml` | loadout | Primary config: user identity, active orgs, tool versions, paths |
 | `~/.dotfiles/build/` | loadout | Merged build output (staging area before copy to `~/`) |
 | `~/.dotfiles/backups/` | loadout | Timestamped backups of files before overwrite |
-| `~/.loadout/` | loadout | Runtime state: `logs/`, `backups/`, timestamps, future `manifest.json` |
+| `~/.loadout/` | loadout | Runtime state: `logs/`, `backups/`, timestamps, `manifest.json` |
 | `~/.devbox/` | devbox | `config.json`, `registry.json` (devbox inventory and settings) |
 | `~/.canvas/` | canvas | `config`, `registry.json` (session inventory), `sessions/` (workspace dirs) |
 | `~/.claude/` | loadout / canvas | `mcp.json`, `CLAUDE.md`, `providers/` (API key scripts) |
@@ -369,17 +372,16 @@ Each tool maintains its own state directory. There are no shared databases — t
 
 ## 7. Multi-Org Model
 
-Loadout supports five organizations, each receiving isolated configuration across every tool.
+Loadout supports multiple organizations, each receiving isolated configuration across every tool. Here are some example org slugs:
 
 ### Supported Organizations
 
 | Org Slug | Purpose |
 |---|---|
 | `personal` | Personal projects and default identity |
-| `splash` | Primary employer |
-| `mythical-journeys` | Side project |
-| `sidequest-syndicate` | Side project collective |
-| `equinox-consulting` | Consulting work |
+| `acme-corp` | Primary employer |
+| `side-project` | Side project |
+| `freelance-client` | Consulting or freelance work |
 
 ### Per-Org Configuration Surface
 
@@ -409,7 +411,7 @@ Loadout supports five organizations, each receiving isolated configuration acros
 |---|---|
 | **Base layer** | The public `dotfiles` repo containing universal macOS defaults. First (lowest priority) merge layer. |
 | **Org layer** | Per-organization configuration in `dotfiles-private`. Overrides the base layer. |
-| **Private layer** | The combination of `dotfiles-private/dotfiles/base/` and org overlays. Higher priority than public base. |
+| **Private layer** | The combination of `dotfiles-private/dotfiles/base/` (private base) and `dotfiles-private/dotfiles/orgs/` (org overlays). In the high-level view this is a single "Private layer"; in the merge pipeline it expands into two distinct priority levels (private base at priority 2, org overlays at priority 3). |
 | **Overlay hook** | A well-known file path (`~/.zshrc.d/`, `~/.gitconfig.d/`, `~/.zshrc.local`) that allows runtime customization without rebuilding. |
 | **Three-layer merge** | The build pipeline that combines public base, private base, and org overlays into final dotfiles. |
 | **Loadout** | Both the ecosystem name and the orchestrator CLI (`oakensoul/loadout`). |
@@ -423,6 +425,6 @@ Loadout supports five organizations, each receiving isolated configuration acros
 | **Atrophy detection** | Health check that identifies devbox environments with no recent activity, candidates for `devbox nuke`. |
 | **`op://` URI** | A 1Password CLI reference (e.g., `op://vault/item/field`) resolved at runtime by `op read`. No secrets are stored in config files. |
 | **Dynamic profile** | An iTerm2 feature where JSON files in `~/Library/Application Support/iTerm2/DynamicProfiles/` are auto-loaded as terminal profiles. |
-| **AIDA** | A future plugin system. All three Python CLIs expose `core.py` stable APIs for AIDA integration. |
+| **AIDA** | A Claude Code plugin system that provides agent, skill, and hook management. The three Python CLIs expose `core.py` stable APIs for AIDA integration. |
 | **`loadout check`** | Health probe command that inspects git status, brew state, stale canvas sessions, devbox heartbeats, and disk space. |
 | **Atomic swap** | The build module writes merged output to a staging directory (`~/.dotfiles/build/`) then copies to `~/`, minimizing the window of inconsistent state. |


### PR DESCRIPTION
## Summary
- Rewrote README.md as a concise gateway with layer model visual, prerequisites, and quick start
- Created `docs/SETUP.md` — comprehensive 8-part getting started guide (prerequisites through uninstall)
- Committed existing `docs/architecture/README.md` to version control
- Updated architecture docs for current system state (base/ pattern, canvas/devbox init, private defaults)
- Updated CLAUDE.md with current commands, directory layout, and cross-references
- Added "manual alternative to loadout init" notes to bootstrap script headers
- Added cross-references between all documentation files

Closes #4

## Test plan
- [x] All 10 validation checks pass
- [x] No personal info, usernames, or machine-specific paths
- [x] Cross-references between README, SETUP.md, architecture docs, and CLAUDE.md verified
- [ ] Review rendered markdown on GitHub for formatting