### PR TITLE
Remove separate cookiecutter install step from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The recommended way to set up a new machine is with the `loadout` CLI:
 # 1. Install Homebrew (if not already installed)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# 2. Install loadout with scaffold support (not yet on PyPI — install from source)
+# 2. Install loadout (not yet on PyPI — install from source)
 git clone https://github.com/oakensoul/loadout.git ~/.loadout-cli
-pip3 install ~/.loadout-cli[scaffold]
+pip3 install ~/.loadout-cli
 
 # 3. Scaffold your private repo (creates ~/.dotfiles-private with correct structure)
 loadout scaffold \

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,7 +33,7 @@ Before running the setup, make sure you have:
 - **Apple ID** — Required for installing Xcode Command Line Tools. If you are on a managed machine, your IT department may need to allow this.
 - **GitHub account** — Your dotfiles repos are hosted on GitHub. [Create an account](https://github.com/signup) if you do not have one.
 - **1Password account** (recommended) — Loadout uses the 1Password CLI (`op`) for SSH key management and secrets. You can skip this, but you will need to manage SSH keys manually.
-- **cookiecutter** (optional) — Required if you want to use `loadout scaffold` to generate your private repo. Install it with `pip3 install cookiecutter>=2.0` or use `pip3 install ~/.loadout-cli[scaffold]` when installing loadout.
+- **cookiecutter** — Included automatically when you install loadout. No separate install needed.
 
 ### Fork or Clone?
 
@@ -79,11 +79,6 @@ Your private repo (`dotfiles-private`) holds personal identity, org-specific con
 The `loadout scaffold` command generates a properly structured `dotfiles-private` repo using a cookiecutter template. This is the fastest way to get started.
 
 ```bash
-# If you installed loadout with scaffold support:
-pip3 install ~/.loadout-cli[scaffold]
-# OR install cookiecutter separately:
-pip3 install cookiecutter>=2.0
-
 # Scaffold your private repo
 loadout scaffold \
   --user=YOUR_USERNAME \


### PR DESCRIPTION
## Summary
- cookiecutter is now a core dependency of loadout (see oakensoul/loadout#56)
- Removed separate `pip3 install cookiecutter` instructions from SETUP.md and README
- Updated prerequisites to note cookiecutter is included automatically

## Test plan
- [x] Validation passes