### PR TITLE
Set ssh-keygen as default SSH signing program

### DIFF
--- a/dotfiles/base/.gitconfig
+++ b/dotfiles/base/.gitconfig
@@ -30,6 +30,9 @@
     autoSquash = true
     autoStash = true
 
+[gpg "ssh"]
+    program = ssh-keygen
+
 [alias]
     st = status
     co = checkout


### PR DESCRIPTION
## Summary
- Add `[gpg "ssh"] program = ssh-keygen` to base .gitconfig
- Uses macOS keychain-backed local keys instead of 1Password SSH agent for commit signing
- Eliminates repeated 1Password authentication prompts for every git commit

## Test plan
- [x] All 10 validation checks pass
- [x] Verified commit signing works with local keys + macOS keychain