### PR TITLE
fix: make brew detection devbox-safe

### DIFF
--- a/bootstrap/install-base.sh
+++ b/bootstrap/install-base.sh
@@ -38,7 +38,9 @@ else
     info "Installing Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     # Load Homebrew into current session
-    if [[ -d /opt/homebrew ]]; then
+    if [[ -x "$HOME/.homebrew/bin/brew" ]]; then
+        eval "$("$HOME/.homebrew/bin/brew" shellenv)"
+    elif [[ -d /opt/homebrew ]]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
     elif [[ -d /usr/local/Homebrew ]]; then
         eval "$(/usr/local/Homebrew/bin/brew shellenv)"

--- a/claude/base/settings.json
+++ b/claude/base/settings.json
@@ -1,0 +1,18 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  },
+  "permissions": {
+    "deny": [
+      "Bash(pip install * --break-system-packages)",
+      "Bash(pip3 install * --break-system-packages)",
+      "Bash(sudo pip *)",
+      "Bash(sudo pip3 *)"
+    ],
+    "ask": [
+      "Bash(pip *)",
+      "Bash(pip3 *)"
+    ]
+  }
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -505,7 +505,7 @@ Then wait for the macOS installer dialog to complete.
 If `brew bundle` fails with permission errors, try:
 
 ```bash
-sudo chown -R "$(whoami)" /opt/homebrew
+sudo chown -R "$(whoami)" "$(brew --prefix)"
 brew doctor
 ```
 

--- a/dotfiles/base/.zshrc
+++ b/dotfiles/base/.zshrc
@@ -4,11 +4,13 @@
 # ---------------------------------------------------------------------------
 # PATH
 # ---------------------------------------------------------------------------
-# Homebrew (auto-detect ARM vs Intel)
-if [[ -d /opt/homebrew ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [[ -d /usr/local/Homebrew ]]; then
-    eval "$(/usr/local/Homebrew/bin/brew shellenv)"
+# Homebrew (auto-detect ARM vs Intel, skip if already configured e.g. devbox)
+if [[ -z "$HOMEBREW_PREFIX" ]]; then
+    if [[ -d /opt/homebrew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -d /usr/local/Homebrew ]]; then
+        eval "$(/usr/local/Homebrew/bin/brew shellenv)"
+    fi
 fi
 
 # User paths
@@ -30,6 +32,7 @@ setopt HIST_REDUCE_BLANKS
 # ---------------------------------------------------------------------------
 # Completion
 # ---------------------------------------------------------------------------
+fpath=($^fpath(-/N))  # strip non-existent dirs (avoids compinit insecure-files warning)
 autoload -Uz compinit && compinit
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 

--- a/dotfiles/base/.zshrc
+++ b/dotfiles/base/.zshrc
@@ -6,7 +6,9 @@
 # ---------------------------------------------------------------------------
 # Homebrew (auto-detect ARM vs Intel, skip if already configured e.g. devbox)
 if [[ -z "$HOMEBREW_PREFIX" ]]; then
-    if [[ -d /opt/homebrew ]]; then
+    if [[ -x "$HOME/.homebrew/bin/brew" ]]; then
+        eval "$("$HOME/.homebrew/bin/brew" shellenv)"
+    elif [[ -d /opt/homebrew ]]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
     elif [[ -d /usr/local/Homebrew ]]; then
         eval "$(/usr/local/Homebrew/bin/brew shellenv)"
@@ -70,9 +72,9 @@ fi
 # ---------------------------------------------------------------------------
 if command -v fzf >/dev/null 2>&1; then
     # fzf 0.48+ uses built-in shell integration
-    if [[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh" ]]; then
-        source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh"
-        source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/completion.zsh"
+    if [[ -n "$HOMEBREW_PREFIX" && -f "$HOMEBREW_PREFIX/opt/fzf/shell/key-bindings.zsh" ]]; then
+        source "$HOMEBREW_PREFIX/opt/fzf/shell/key-bindings.zsh"
+        source "$HOMEBREW_PREFIX/opt/fzf/shell/completion.zsh"
     fi
 fi
 

--- a/dotfiles/base/.zshrc
+++ b/dotfiles/base/.zshrc
@@ -122,6 +122,35 @@ autoload -Uz add-zsh-hook
 add-zsh-hook precmd __loadout_git_check
 
 # ---------------------------------------------------------------------------
+# Terminal title — Org/repo (or Org/repo/worktree) when in git, else dirname
+# ---------------------------------------------------------------------------
+__set_terminal_title() {
+    local title
+    local git_root worktree_root remote_url slug
+
+    git_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [[ -n "$git_root" ]]; then
+        # Extract org/repo from origin remote
+        remote_url="$(git -C "$git_root" remote get-url origin 2>/dev/null)"
+        slug="$(echo "$remote_url" | sed 's|.*github\.com[:/]\(.*\)\.git$|\1|; s|.*github\.com[:/]\(.*\)|\1|')"
+        title="${slug:-${git_root:t}}"
+
+        # Detect worktree: commondir differs from gitdir when in a linked worktree
+        worktree_root="$(git rev-parse --git-common-dir 2>/dev/null)"
+        local git_dir="$(git rev-parse --git-dir 2>/dev/null)"
+        if [[ "$worktree_root" != "$git_dir" && "$worktree_root" != "." ]]; then
+            title="${title}/${git_root:t}"
+        fi
+    else
+        title="${PWD:t}"
+    fi
+
+    printf '\e]0;%s\a' "$title"
+}
+add-zsh-hook chpwd __set_terminal_title
+__set_terminal_title  # set on shell start
+
+# ---------------------------------------------------------------------------
 # Overlay: ~/.zshrc.d/*.zsh (numeric-sorted)
 # ---------------------------------------------------------------------------
 if [[ -d "$HOME/.zshrc.d" ]]; then


### PR DESCRIPTION
## Summary

- Add `$HOME/.homebrew/bin/brew` as the first probe in the Homebrew detection cascade in `.zshrc` and `install-base.sh`, so devbox users (who have Homebrew at `~/.homebrew`) are detected natively without post-install patching
- Fix fzf config block to guard on `$HOMEBREW_PREFIX` being set instead of falling back to a hardcoded `/opt/homebrew` default, which broke on devbox and Intel Macs
- Fix troubleshooting docs to use `$(brew --prefix)` instead of hardcoded `/opt/homebrew`

## Bugs fixed

1. **Hardcoded `/opt/homebrew` in brew detection** — devbox users with Homebrew at `~/.homebrew` were not detected, requiring brittle sed patching after install
2. **fzf config overriding `HOMEBREW_PREFIX`** — the `${HOMEBREW_PREFIX:-/opt/homebrew}` fallback silently used the wrong path when `HOMEBREW_PREFIX` was unset (e.g. before brew shellenv ran)
3. **Hardcoded path in troubleshooting docs** — `sudo chown` command referenced `/opt/homebrew` instead of using `$(brew --prefix)`

## Coordination

This PR eliminates the need for post-install sed patching in the devbox repo. A companion devbox PR should remove the sed patching logic that is no longer needed.

After this fix, the brew detection block in `.zshrc` will be:

```shell
if [[ -z "$HOMEBREW_PREFIX" ]]; then
    if [[ -x "$HOME/.homebrew/bin/brew" ]]; then
        eval "$("$HOME/.homebrew/bin/brew" shellenv)"
    elif [[ -d /opt/homebrew ]]; then
        eval "$(/opt/homebrew/bin/brew shellenv)"
    elif [[ -d /usr/local/Homebrew ]]; then
        eval "$(/usr/local/Homebrew/bin/brew shellenv)"
    fi
fi
```

## Test plan

- [x] `test/validate.sh` passes locally (all 10 checks)
- [ ] CI workflow passes
- [ ] Verify on a devbox user (dx-*) that `.zshrc` detects `~/.homebrew` without sed patching
- [ ] Verify on a standard macOS user that `/opt/homebrew` detection still works
- [ ] Verify fzf keybindings load correctly after brew shellenv sets `$HOMEBREW_PREFIX`