### PR TITLE
feat: add dotfiles-expert Claude Code agent

### DIFF
--- a/.claude/agents/dotfiles-expert/dotfiles-expert.md
+++ b/.claude/agents/dotfiles-expert/dotfiles-expert.md
@@ -1,0 +1,48 @@
+---
+name: dotfiles-expert
+description: Expert on the Loadout macOS machine configuration ecosystem — answers questions about architecture, configuration, repo relationships, merge strategies, and workflows across all 5 repos (dotfiles, loadout, devbox, canvas, dotfiles-private).
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - WebSearch
+  - WebFetch
+---
+
+# Dotfiles Expert
+
+You are an expert on the **Loadout** macOS machine configuration ecosystem. You have deep knowledge of all 5 repositories and how they work together.
+
+## Your Role
+
+Answer questions about:
+- How the Loadout ecosystem works (architecture, data flow, bootstrap lifecycle)
+- Where specific configurations live across the 5 repos
+- How the merge strategy works (concat, git-include, deep-merge, replace)
+- How multi-org support is implemented
+- How secrets are managed (1Password, op:// URIs)
+- How devbox and canvas integrate with the config layers
+- State locations and file paths
+- Troubleshooting configuration issues
+
+## How to Answer
+
+1. **Check your knowledge documents first** — they contain the authoritative architecture overview
+2. **Read actual files when needed** — knowledge docs may be stale; verify against current code
+3. **Search across all 5 repos** when the question spans multiple repos:
+   - `/Users/oakensoul/Developer/oakensoul/dotfiles` (public base layer)
+   - `/Users/oakensoul/Developer/oakensoul/loadout` (orchestrator CLI)
+   - `/Users/oakensoul/Developer/oakensoul/dotfiles-private` (private org layer)
+   - `/Users/oakensoul/Developer/oakensoul/devbox` (dev environments CLI)
+   - `/Users/oakensoul/Developer/oakensoul/canvas` (Claude Code sessions CLI)
+4. **Be precise** — include file paths and line numbers when referencing code
+5. **Be concise** — answer the question directly, then provide context if needed
+
+## Important Context
+
+- All repos use AGPL-3.0 licensing
+- All secrets use 1Password CLI (`op read "op://..."`) — never hardcoded
+- All Python CLIs expose a stable `core.py` API for future AIDA plugin integration
+- The dotfiles repo is public — never reference personal data from dotfiles-private

--- a/.claude/agents/dotfiles-expert/dotfiles-expert.md
+++ b/.claude/agents/dotfiles-expert/dotfiles-expert.md
@@ -31,12 +31,12 @@ Answer questions about:
 
 1. **Check your knowledge documents first** — they contain the authoritative architecture overview
 2. **Read actual files when needed** — knowledge docs may be stale; verify against current code
-3. **Search across all 5 repos** when the question spans multiple repos:
-   - `/Users/oakensoul/Developer/oakensoul/dotfiles` (public base layer)
-   - `/Users/oakensoul/Developer/oakensoul/loadout` (orchestrator CLI)
-   - `/Users/oakensoul/Developer/oakensoul/dotfiles-private` (private org layer)
-   - `/Users/oakensoul/Developer/oakensoul/devbox` (dev environments CLI)
-   - `/Users/oakensoul/Developer/oakensoul/canvas` (Claude Code sessions CLI)
+3. **Search across all 5 repos** when the question spans multiple repos (paths relative to `~/Developer/oakensoul/`):
+   - `dotfiles` (public base layer)
+   - `loadout` (orchestrator CLI)
+   - `dotfiles-private` (private org layer)
+   - `devbox` (dev environments CLI)
+   - `canvas` (Claude Code sessions CLI)
 4. **Be precise** — include file paths and line numbers when referencing code
 5. **Be concise** — answer the question directly, then provide context if needed
 

--- a/.claude/agents/dotfiles-expert/dotfiles-expert.md
+++ b/.claude/agents/dotfiles-expert/dotfiles-expert.md
@@ -31,7 +31,7 @@ Answer questions about:
 
 1. **Check your knowledge documents first** — they contain the authoritative architecture overview
 2. **Read actual files when needed** — knowledge docs may be stale; verify against current code
-3. **Search across all 5 repos** when the question spans multiple repos (paths relative to `~/Developer/oakensoul/`):
+3. **Search across all 5 repos** when the question spans multiple repos (paths relative to `~/Developer/{github-user}/`):
    - `dotfiles` (public base layer)
    - `loadout` (orchestrator CLI)
    - `dotfiles-private` (private org layer)

--- a/.claude/agents/dotfiles-expert/knowledge/bootstrap-lifecycle.md
+++ b/.claude/agents/dotfiles-expert/knowledge/bootstrap-lifecycle.md
@@ -1,0 +1,82 @@
+---
+name: bootstrap-lifecycle
+description: The loadout init 12-step bootstrap and daily update/upgrade workflows
+---
+
+# Bootstrap & Lifecycle
+
+## loadout init — Full Machine Bootstrap (12 Steps)
+
+Run once on a fresh machine: `loadout init --user=NAME --orgs=ORG1 --orgs=ORG2`
+
+1. **Ensure Xcode CLI Tools** — headless install if missing
+2. **Clone ~/.dotfiles** — public base repo from GitHub
+3. **Clone ~/.dotfiles-private** — private org config repo
+4. **Generate SSH key** — ed25519 format
+5. **Register SSH key with GitHub** — via 1Password token + gh CLI
+6. **Switch git remotes to SSH** — https → git@github.com:
+7. **Build dotfiles** — merge 3 layers → atomic swap → install to ~/
+8. **Brew bundle** — install all Brewfile fragments
+9. **Install globals** — nvm + Node LTS, pyenv + Python, Claude Code, npm/pip globals
+10. **Build Claude config** — assemble mcp.json + CLAUDE.md + providers
+11. **Apply macOS defaults** — hardware-appropriate scripts (desktop vs laptop vs docked)
+12. **Set up display launch agent** — launchctl for auto-detection daemon
+
+Saves state to `~/.dotfiles/.loadout.toml` on completion.
+
+## loadout update — Daily Safe Sync
+
+Safe to run daily: `loadout update`
+
+1. `git pull --ff-only` both repos (fails if local changes)
+2. Rebuild merged dotfiles (atomic swap)
+3. Build Claude config
+4. `brew update && brew bundle` (install new packages only)
+5. Install globals (check-before-install, safe)
+
+## loadout upgrade — Update + Brew Upgrade
+
+Potentially breaking: `loadout upgrade`
+
+Same as update, plus `brew upgrade` (updates existing packages to latest versions).
+
+## loadout build — Merge Pipeline Only
+
+Just the dotfile merge: `loadout build`
+
+Useful for testing merge changes without pulling or installing packages.
+
+## loadout globals — Package Installation Only
+
+Just global tools: `loadout globals`
+
+1. Ensure nvm + Node LTS
+2. Ensure Claude Code CLI
+3. Ensure pyenv + Python
+4. Run globals.base.sh
+5. Run globals.private.sh (optional)
+6. Install org globals scripts to ~/.zshrc.d/
+7. Install npm globals (from npm-globals.txt files)
+8. Install pip globals (from pip-globals.txt files)
+
+## loadout check — Health Probes (Read-Only)
+
+Never mutates: `loadout check`
+
+Probes: Homebrew, Git, Node.js, Python, 1Password CLI, GitHub SSH, Claude Code, Brewfile fragments, globals scripts, Claude config files.
+
+## loadout display — Power Profile Switching
+
+`loadout display [connected|solo]`
+
+Detects hardware (MacBook vs desktop) and display count, applies appropriate power management profile:
+- Desktop → never sleep, display sleep 10m
+- Laptop solo → battery-friendly (sleep 15m, display 5m)
+- Laptop connected/docked → desktop-like on AC
+
+## Legacy Bootstrap Scripts (in dotfiles repo)
+
+The dotfiles repo also has standalone bootstrap scripts for use without the loadout CLI:
+- `bootstrap/install-base.sh` — Xcode, Homebrew, Brewfile.base, globals
+- `bootstrap/install-user.sh` — backup dotfiles, copy base configs to ~/
+- `bootstrap/install-devbox.sh` — dev packages, devbox overlay, display detection

--- a/.claude/agents/dotfiles-expert/knowledge/ecosystem-overview.md
+++ b/.claude/agents/dotfiles-expert/knowledge/ecosystem-overview.md
@@ -26,7 +26,7 @@ Loadout is a multi-repo macOS machine configuration system with **5 repositories
 ### dotfiles-private — Private Org Layer
 - **Type**: Git config repo (cloned to `~/.dotfiles-private`)
 - **Purpose**: Org-specific secrets, identity, and configuration overrides
-- **Orgs**: personal, splash, mythical-journeys, sidequest-syndicate, equinox-consulting
+- **Orgs**: user-defined (configured via `loadout init --orgs=...`)
 - **Structure**: Each top-level dir has `base/` (shared private) + `orgs/` (per-org) subdirs
 - **Key contents**: Git identity, secrets (op:// refs), Brewfiles, Claude configs, devbox presets, canvas templates
 - **Status**: Active development (feature branch)

--- a/.claude/agents/dotfiles-expert/knowledge/ecosystem-overview.md
+++ b/.claude/agents/dotfiles-expert/knowledge/ecosystem-overview.md
@@ -1,0 +1,76 @@
+---
+name: ecosystem-overview
+description: High-level overview of the 5-repo Loadout macOS machine configuration system and each repo's role
+---
+
+# Loadout Ecosystem Overview
+
+Loadout is a multi-repo macOS machine configuration system with **5 repositories** that serve **3 roles**: orchestration, base config, and specialized tooling.
+
+## Repositories
+
+### loadout — The Orchestrator
+- **Type**: Python CLI (Click + Rich + PyYAML)
+- **Purpose**: Machine configuration orchestration — clones config repos, merges dotfile layers, installs packages, configures macOS, sets up Claude Code
+- **Commands**: `init`, `build`, `update`, `upgrade`, `check`, `globals`, `display`
+- **State**: `~/.dotfiles/.loadout.toml` (user, orgs, versions)
+- **Status**: v0.1.0 Beta, 95%+ test coverage
+
+### dotfiles — Public Base Layer
+- **Type**: Git config repo (cloned to `~/.dotfiles`)
+- **Purpose**: Universal macOS defaults — shell config, git config, aliases, Brewfiles, macOS defaults scripts, Claude Code templates, iTerm2 profile generator, bootstrap scripts
+- **Key dirs**: `bootstrap/`, `brewfiles/`, `globals/`, `dotfiles/base/`, `dotfiles/devbox/`, `macos/`, `claude/`, `iterm2/`, `test/`
+- **Design**: Idempotent scripts, no symlinks (copy-based), overlay hooks
+- **Status**: Stable, public, AGPL-3.0
+
+### dotfiles-private — Private Org Layer
+- **Type**: Git config repo (cloned to `~/.dotfiles-private`)
+- **Purpose**: Org-specific secrets, identity, and configuration overrides
+- **Orgs**: personal, splash, mythical-journeys, sidequest-syndicate, equinox-consulting
+- **Structure**: Each top-level dir has `base/` (shared private) + `orgs/` (per-org) subdirs
+- **Key contents**: Git identity, secrets (op:// refs), Brewfiles, Claude configs, devbox presets, canvas templates
+- **Status**: Active development (feature branch)
+
+### devbox — Disposable Dev Environments
+- **Type**: Python CLI (Click + Pydantic v2 + Rich + Requests)
+- **Purpose**: Create and manage disposable SSH-only macOS user accounts (`dx-*` prefix) for project-scoped development
+- **Commands**: `create`, `list`, `nuke`, `rebuild`
+- **Features**: macOS user lifecycle (dscl), SSH keys + GitHub registration, iTerm2 profiles, preset-driven config, compensation stack for rollback
+- **State**: `~/.devbox/` (config.json, registry.json)
+- **Status**: v0.1.0 Alpha, 90%+ test coverage
+
+### canvas — Claude Code Workspace Sessions
+- **Type**: Python CLI (Click + Rich + Jinja2)
+- **Purpose**: Ephemeral org-aware Claude Code workspace manager
+- **Commands**: `new`, `list`, `show`, `archive`, `nuke`, `rename`, `open`
+- **Features**: Org-aware CLAUDE.md rendering from Jinja2 templates, human-friendly slugs (YYYY-MM-DD-adjective-noun), JSON registry, iTerm2 integration, stale session detection
+- **State**: `~/.canvas/` (config, registry.json, sessions/)
+- **Status**: v0.1.0 Alpha, 95%+ test coverage
+
+## Relationships
+
+```
+loadout (orchestrator)
+  ├── reads from: dotfiles (base layer)
+  ├── reads from: dotfiles-private (org layer)
+  ├── merges → builds → installs to ~/
+  └── exposes core.py API for future AIDA plugin
+
+devbox (standalone CLI)
+  ├── reads presets from: dotfiles-private/devbox/presets/
+  ├── creates macOS user accounts
+  └── exposes core.py API for future AIDA plugin
+
+canvas (standalone CLI)
+  ├── reads templates from: dotfiles-private/canvas/orgs/
+  ├── creates session dirs under ~/.canvas/sessions/
+  └── exposes core.py API for future AIDA plugin
+```
+
+## Shared Infrastructure
+
+- **1Password CLI** (`op`) — secrets for all tools
+- **iTerm2** — visual identity (color-coded per org, dynamic profiles)
+- **GitHub CLI** (`gh`) — SSH key registration, PR workflows
+- **All 3 Python CLIs** expose `core.py` stable APIs for AIDA plugin integration
+- **AGPL-3.0** licensing across all repos

--- a/.claude/agents/dotfiles-expert/knowledge/index.md
+++ b/.claude/agents/dotfiles-expert/knowledge/index.md
@@ -1,0 +1,16 @@
+---
+name: index
+description: Catalog of knowledge documents for the dotfiles-expert agent
+---
+
+# Dotfiles Expert Knowledge Index
+
+| Document | Description |
+|----------|-------------|
+| [ecosystem-overview](ecosystem-overview.md) | High-level overview of the 5-repo Loadout system and each repo's role |
+| [merge-strategy](merge-strategy.md) | How loadout build merges dotfiles across 3 layers with per-file strategies |
+| [bootstrap-lifecycle](bootstrap-lifecycle.md) | The loadout init 12-step bootstrap and daily update/upgrade workflows |
+| [org-model](org-model.md) | Multi-org support: 5 orgs, per-org config surfaces, identity resolution |
+| [secrets-and-security](secrets-and-security.md) | 1Password integration, secret patterns, security validation |
+| [state-locations](state-locations.md) | Where each tool stores config, state, and runtime data |
+| [repo-locations](repo-locations.md) | Source code paths and key file locations in each repo |

--- a/.claude/agents/dotfiles-expert/knowledge/merge-strategy.md
+++ b/.claude/agents/dotfiles-expert/knowledge/merge-strategy.md
@@ -1,0 +1,79 @@
+---
+name: merge-strategy
+description: How loadout build merges dotfiles across 3 layers with per-file-type strategies
+---
+
+# Merge Strategy
+
+## Layer Priority (lowest → highest)
+
+1. **Public base**: `~/.dotfiles/dotfiles/base/` — universal defaults
+2. **Private base**: `~/.dotfiles-private/dotfiles/base/` — shared private config (optional)
+3. **Org overlays**: `~/.dotfiles-private/dotfiles/orgs/{org}/` — one per configured org, applied in order
+
+Later layers override or extend earlier layers. The strategy depends on file type.
+
+## Per-File Merge Strategies
+
+| File Pattern | Strategy | Behavior |
+|---|---|---|
+| `.zshrc`, `.aliases`, `.zprofile`, `.zshenv` | **Concat** | Layers appended with separator comments between them |
+| `.gitconfig` | **Git include** | Base written to dest; org configs → `~/.gitconfig.d/{org}`; `[include]` directives appended |
+| `*.json` | **Deep merge** | Recursive dict merge; later layers win on key conflicts; pretty-printed (indent=2) |
+| `*.yaml`, `*.yml` | **Deep merge** | Recursive dict merge; later layers win on key conflicts |
+| Everything else | **Replace** | Later layer file completely replaces earlier version |
+
+## Shell Overlay System
+
+`~/.zshrc.d/*.zsh` files are sourced in numeric order:
+
+| Prefix | Source | Purpose |
+|---|---|---|
+| `10-*` | Org layer | Team/company shell extensions |
+| `50-*` | Devbox layer | Developer tool aliases (docker, gh, npm, lazygit) |
+| `90-*` | Private layer | Personal overrides |
+
+Loading order in `.zshrc`:
+1. PATH setup (Homebrew auto-detect ARM vs Intel)
+2. User bin directories
+3. History config + completion
+4. `~/.aliases`
+5. Tool integrations (nvm, pyenv, zoxide, fzf)
+6. Background git fetch hook
+7. `~/.zshrc.d/*.zsh` (numeric-sorted)
+8. `~/.zshrc.local` (final private overrides)
+
+## Git Overlay System
+
+- `~/.gitconfig` — base config (no `[user]` section)
+- `~/.gitconfig.d/` — org-specific configs via `[include]` directives
+- `~/.gitconfig.local` — personal identity and final overrides (sourced last)
+
+Identity is managed via conditional includes: `[includeIf "gitdir:~/Developer/{org}/"]`
+
+## Atomic Build Process
+
+1. Create temp directory in `~/.dotfiles/`
+2. Build all merged files into temp dir
+3. Atomic rename: temp → `~/.dotfiles/build/`
+4. Backup existing files to `~/.dotfiles/backups/{filename}.{timestamp}`
+5. Copy built files to `~/`
+6. On failure, temp dir is cleaned up (no partial writes)
+
+## Brewfile Assembly
+
+Fragments concatenated in order:
+1. `~/.dotfiles/brewfiles/Brewfile.base` (always)
+2. `~/.dotfiles-private/brewfiles/Brewfile.private` (if exists)
+3. `~/.dotfiles-private/brewfiles/orgs/Brewfile.{org}` (per configured org)
+
+Result passed to `brew bundle --file=<temp> --no-lock`.
+
+## Claude Code Config Assembly
+
+| Source files | Target | Strategy |
+|---|---|---|
+| `mcp-shared.json` + `mcp-private.json` + `mcp-{org}.json` | `~/.claude/mcp.json` | Deep merge |
+| `CLAUDE.md.template` + base CLAUDE.md + org CLAUDE.md | `~/.claude/CLAUDE.md` | Concatenation |
+| `statusline.sh` | `~/.claude/statusline.sh` | Copy |
+| `providers/*.sh` | `~/.claude/providers/` | Copy + chmod 755 |

--- a/.claude/agents/dotfiles-expert/knowledge/merge-strategy.md
+++ b/.claude/agents/dotfiles-expert/knowledge/merge-strategy.md
@@ -18,7 +18,7 @@ Later layers override or extend earlier layers. The strategy depends on file typ
 | File Pattern | Strategy | Behavior |
 |---|---|---|
 | `.zshrc`, `.aliases`, `.zprofile`, `.zshenv` | **Concat** | Layers appended with separator comments between them |
-| `.gitconfig` | **Git include** | Base written to dest; org configs → `~/.gitconfig.d/{org}`; `[include]` directives appended |
+| `.gitconfig` | **Git include** | Base written to dest; org configs merged → `~/.gitconfig.d/org.gitconfig`; included via `[include] path` |
 | `*.json` | **Deep merge** | Recursive dict merge; later layers win on key conflicts; pretty-printed (indent=2) |
 | `*.yaml`, `*.yml` | **Deep merge** | Recursive dict merge; later layers win on key conflicts |
 | Everything else | **Replace** | Later layer file completely replaces earlier version |
@@ -29,9 +29,9 @@ Later layers override or extend earlier layers. The strategy depends on file typ
 
 | Prefix | Source | Purpose |
 |---|---|---|
-| `10-*` | Org layer | Team/company shell extensions |
-| `50-*` | Devbox layer | Developer tool aliases (docker, gh, npm, lazygit) |
-| `90-*` | Private layer | Personal overrides |
+| `10-*` | Org layer | Team/company shell extensions (convention enforced by `loadout build`) |
+| `50-*` | Devbox layer | Developer tool aliases (convention enforced by `loadout build`) |
+| `90-*` | Private layer | Personal overrides (convention enforced by `loadout build`) |
 
 Loading order in `.zshrc`:
 1. PATH setup (Homebrew auto-detect ARM vs Intel)
@@ -45,11 +45,11 @@ Loading order in `.zshrc`:
 
 ## Git Overlay System
 
-- `~/.gitconfig` — base config (no `[user]` section)
-- `~/.gitconfig.d/` — org-specific configs via `[include]` directives
+- `~/.gitconfig` — base config (no `[user]` section), includes org config via `[include] path = ~/.gitconfig.d/org.gitconfig`
+- `~/.gitconfig.d/org.gitconfig` — single merged file containing all org git configs
 - `~/.gitconfig.local` — personal identity and final overrides (sourced last)
 
-Identity is managed via conditional includes: `[includeIf "gitdir:~/Developer/{org}/"]`
+Identity is managed via conditional includes in the org config: `[includeIf "gitdir:~/Developer/{org}/"]`
 
 ## Atomic Build Process
 

--- a/.claude/agents/dotfiles-expert/knowledge/org-model.md
+++ b/.claude/agents/dotfiles-expert/knowledge/org-model.md
@@ -1,0 +1,65 @@
+---
+name: org-model
+description: Multi-org support — 5 orgs, per-org config surfaces, identity resolution
+---
+
+# Multi-Org Model
+
+## Supported Organizations
+
+| Org Slug | GitHub Identity | Description |
+|---|---|---|
+| `personal` | oakensoul | Personal projects |
+| `splash` | splash-rob | Splash Sports (employer) |
+| `mythical-journeys` | TBD | Side project (game/LARP) |
+| `sidequest-syndicate` | TBD | Side project collective |
+| `equinox-consulting` | TBD | Consulting work |
+
+## Per-Org Configuration Surface
+
+Each org can have any/all of:
+
+| Config Type | Location in dotfiles-private | Purpose |
+|---|---|---|
+| Git identity | `dotfiles/orgs/{org}/.gitconfig` | user.name, user.email, signing key |
+| Shell globals | `globals/orgs/globals.{org}.sh` | Env vars (secrets via op://) |
+| Brewfile | `brewfiles/orgs/Brewfile.{org}` | Org-specific packages |
+| Claude CLAUDE.md | `claude/orgs/{org}/CLAUDE.md` | Org instructions for Claude |
+| Claude MCP | `claude/orgs/{org}/mcp-{org}.json` | MCP server config |
+| Claude providers | `claude/providers/anthropic-{org}.sh`, `bedrock-{org}.sh` | API key providers |
+| Shell config | `dotfiles/orgs/{org}/.zshrc` | Org shell extensions |
+| Devbox presets | `devbox/presets/{project}.json` | Per-project dev environment presets |
+| Canvas templates | `canvas/orgs/{org}/CLAUDE.md.tmpl` | Jinja2 session templates |
+| Slack | `slack/{org}/slack-workspaces.json` | Workspace URLs |
+
+## Org Selection
+
+### loadout
+- Set at init: `loadout init --orgs=personal --orgs=splash`
+- Stored in `~/.dotfiles/.loadout.toml` → `orgs = ["personal", "splash"]`
+- Multiple orgs can be active simultaneously (configs merged in order)
+
+### canvas
+- Set in `~/.canvas/config` (JSON with `org` field)
+- Written by `loadout init`
+- Single active org at a time (determines which CLAUDE.md.tmpl to render)
+
+### devbox
+- Set per-devbox via preset: `devbox create mybox --preset=splash-data`
+- Preset's `mcp_profile` field selects org context
+- Each devbox has exactly one org/preset
+
+## Git Identity Resolution
+
+Git identity is never in the public base `.gitconfig`. Instead:
+
+1. Base `.gitconfig` includes `~/.gitconfig.local` and `~/.gitconfig.d/`
+2. `loadout build` writes org configs to `~/.gitconfig.d/{org}.gitconfig`
+3. Each org gitconfig uses `[includeIf "gitdir:~/Developer/{org}/"]` for path-based identity
+4. When you `cd` into `~/Developer/splash/some-repo`, git automatically uses the splash identity
+
+## Naming Conventions
+
+- Org slugs: kebab-case (e.g., `mythical-journeys`, `sidequest-syndicate`)
+- Flat files: org in filename (e.g., `globals.personal.sh`, `Brewfile.splash`)
+- Multi-file categories: subdirectory per org (e.g., `orgs/personal/`, `orgs/splash/`)

--- a/.claude/agents/dotfiles-expert/knowledge/org-model.md
+++ b/.claude/agents/dotfiles-expert/knowledge/org-model.md
@@ -7,13 +7,13 @@ description: Multi-org support — 5 orgs, per-org config surfaces, identity res
 
 ## Supported Organizations
 
+Orgs are defined per-user in `~/.dotfiles/.loadout.toml`. Each org has a slug, a GitHub identity, and a description. Example:
+
 | Org Slug | GitHub Identity | Description |
 |---|---|---|
-| `personal` | oakensoul | Personal projects |
-| `splash` | splash-rob | Splash Sports (employer) |
-| `mythical-journeys` | TBD | Side project (game/LARP) |
-| `sidequest-syndicate` | TBD | Side project collective |
-| `equinox-consulting` | TBD | Consulting work |
+| `personal` | {github-user} | Personal projects |
+| `work` | {work-user} | Employer projects |
+| `side-project` | {github-user} | Side project |
 
 ## Per-Org Configuration Surface
 

--- a/.claude/agents/dotfiles-expert/knowledge/org-model.md
+++ b/.claude/agents/dotfiles-expert/knowledge/org-model.md
@@ -1,6 +1,6 @@
 ---
 name: org-model
-description: Multi-org support — 5 orgs, per-org config surfaces, identity resolution
+description: Multi-org support — per-org config surfaces, identity resolution
 ---
 
 # Multi-Org Model
@@ -35,8 +35,8 @@ Each org can have any/all of:
 ## Org Selection
 
 ### loadout
-- Set at init: `loadout init --orgs=personal --orgs=splash`
-- Stored in `~/.dotfiles/.loadout.toml` → `orgs = ["personal", "splash"]`
+- Set at init: `loadout init --orgs=personal --orgs=work`
+- Stored in `~/.dotfiles/.loadout.toml` → `orgs = ["personal", "work"]`
 - Multiple orgs can be active simultaneously (configs merged in order)
 
 ### canvas
@@ -45,7 +45,7 @@ Each org can have any/all of:
 - Single active org at a time (determines which CLAUDE.md.tmpl to render)
 
 ### devbox
-- Set per-devbox via preset: `devbox create mybox --preset=splash-data`
+- Set per-devbox via preset: `devbox create mybox --preset=work-data`
 - Preset's `mcp_profile` field selects org context
 - Each devbox has exactly one org/preset
 
@@ -56,10 +56,10 @@ Git identity is never in the public base `.gitconfig`. Instead:
 1. Base `.gitconfig` includes `~/.gitconfig.local` and `~/.gitconfig.d/`
 2. `loadout build` writes org configs to `~/.gitconfig.d/{org}.gitconfig`
 3. Each org gitconfig uses `[includeIf "gitdir:~/Developer/{org}/"]` for path-based identity
-4. When you `cd` into `~/Developer/splash/some-repo`, git automatically uses the splash identity
+4. When you `cd` into `~/Developer/{org}/some-repo`, git automatically uses that org's identity
 
 ## Naming Conventions
 
-- Org slugs: kebab-case (e.g., `mythical-journeys`, `sidequest-syndicate`)
-- Flat files: org in filename (e.g., `globals.personal.sh`, `Brewfile.splash`)
-- Multi-file categories: subdirectory per org (e.g., `orgs/personal/`, `orgs/splash/`)
+- Org slugs: kebab-case (e.g., `my-company`, `side-project`)
+- Flat files: org in filename (e.g., `globals.personal.sh`, `Brewfile.work`)
+- Multi-file categories: subdirectory per org (e.g., `orgs/personal/`, `orgs/work/`)

--- a/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
+++ b/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
@@ -7,15 +7,15 @@ description: Source code paths and key file locations in each repository
 
 ## Source Repositories
 
-All repos live under `~/Developer/oakensoul/`:
+All repos live under `~/Developer/{github-user}/`:
 
 | Repo | Local Path | GitHub |
 |---|---|---|
-| loadout | `~/Developer/oakensoul/loadout` | oakensoul/loadout |
-| dotfiles | `~/Developer/oakensoul/dotfiles` | oakensoul/dotfiles |
-| dotfiles-private | `~/Developer/oakensoul/dotfiles-private` | oakensoul/dotfiles-private |
-| devbox | `~/Developer/oakensoul/devbox` | oakensoul/devbox |
-| canvas | `~/Developer/oakensoul/canvas` | oakensoul/canvas |
+| loadout | `~/Developer/{github-user}/loadout` | {github-user}/loadout |
+| dotfiles | `~/Developer/{github-user}/dotfiles` | {github-user}/dotfiles |
+| dotfiles-private | `~/Developer/{github-user}/dotfiles-private` | {github-user}/dotfiles-private |
+| devbox | `~/Developer/{github-user}/devbox` | {github-user}/devbox |
+| canvas | `~/Developer/{github-user}/canvas` | {github-user}/canvas |
 
 ## Key Files by Repo
 

--- a/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
+++ b/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
@@ -11,11 +11,11 @@ All repos live under `~/Developer/oakensoul/`:
 
 | Repo | Local Path | GitHub |
 |---|---|---|
-| loadout | `/Users/oakensoul/Developer/oakensoul/loadout` | oakensoul/loadout |
-| dotfiles | `/Users/oakensoul/Developer/oakensoul/dotfiles` | oakensoul/dotfiles |
-| dotfiles-private | `/Users/oakensoul/Developer/oakensoul/dotfiles-private` | oakensoul/dotfiles-private |
-| devbox | `/Users/oakensoul/Developer/oakensoul/devbox` | oakensoul/devbox |
-| canvas | `/Users/oakensoul/Developer/oakensoul/canvas` | oakensoul/canvas |
+| loadout | `~/Developer/oakensoul/loadout` | oakensoul/loadout |
+| dotfiles | `~/Developer/oakensoul/dotfiles` | oakensoul/dotfiles |
+| dotfiles-private | `~/Developer/oakensoul/dotfiles-private` | oakensoul/dotfiles-private |
+| devbox | `~/Developer/oakensoul/devbox` | oakensoul/devbox |
+| canvas | `~/Developer/oakensoul/canvas` | oakensoul/canvas |
 
 ## Key Files by Repo
 
@@ -38,7 +38,7 @@ All repos live under `~/Developer/oakensoul/`:
 - `bootstrap/install-base.sh` — Phase 1: system foundations
 - `bootstrap/install-user.sh` — Phase 2: user dotfiles
 - `bootstrap/install-devbox.sh` — Phase 3: developer tools
-- `dotfiles/base/.zshrc` — Base shell config (135 lines)
+- `dotfiles/base/.zshrc` — Base shell config
 - `dotfiles/base/.gitconfig` — Base git config (no [user])
 - `dotfiles/base/.aliases` — Shell aliases with modern tool replacements
 - `dotfiles/devbox/50-devbox.zsh` — Dev aliases drop-in
@@ -50,6 +50,11 @@ All repos live under `~/Developer/oakensoul/`:
 - `macos/display-watch.sh` — Hardware detection daemon
 - `claude/statusline.sh` — Claude Code status line formatter
 - `iterm2/generate-profile.py` — iTerm2 dynamic profile generator
+- `claude/base/mcp-shared.json` — Base MCP server config
+- `claude/base/settings.json` — Base Claude Code settings
+- `claude/devbox/mcp-devbox.json` — Devbox MCP server config
+- `claude/CLAUDE.md.template` — Template for merged CLAUDE.md
+- `claude/statusline.sh` — Claude Code status line formatter
 - `test/validate.sh` — 10-check validation suite
 - `docs/architecture/README.md` — Ecosystem architecture (C4 diagrams)
 

--- a/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
+++ b/.claude/agents/dotfiles-expert/knowledge/repo-locations.md
@@ -1,0 +1,89 @@
+---
+name: repo-locations
+description: Source code paths and key file locations in each repository
+---
+
+# Repository Locations & Key Files
+
+## Source Repositories
+
+All repos live under `~/Developer/oakensoul/`:
+
+| Repo | Local Path | GitHub |
+|---|---|---|
+| loadout | `/Users/oakensoul/Developer/oakensoul/loadout` | oakensoul/loadout |
+| dotfiles | `/Users/oakensoul/Developer/oakensoul/dotfiles` | oakensoul/dotfiles |
+| dotfiles-private | `/Users/oakensoul/Developer/oakensoul/dotfiles-private` | oakensoul/dotfiles-private |
+| devbox | `/Users/oakensoul/Developer/oakensoul/devbox` | oakensoul/devbox |
+| canvas | `/Users/oakensoul/Developer/oakensoul/canvas` | oakensoul/canvas |
+
+## Key Files by Repo
+
+### loadout
+- `loadout/cli.py` — Click CLI entry point
+- `loadout/core.py` — Stable public API (for AIDA plugins)
+- `loadout/config.py` — LoadoutConfig dataclass + TOML I/O
+- `loadout/build.py` — Dotfile merge engine (MergeStrategy enum)
+- `loadout/init.py` — 12-step machine bootstrap
+- `loadout/brew.py` — Brewfile fragment assembly
+- `loadout/claude.py` — Claude Code config assembly
+- `loadout/globals.py` — nvm/pyenv/npm/pip global installs
+- `loadout/update.py` — Daily update + upgrade flows
+- `loadout/check.py` — Health check probes
+- `loadout/display.py` — macOS display profile detection
+- `loadout/merge.py` — Deep merge utility
+- `docs/architecture/README.md` — Architecture documentation
+
+### dotfiles
+- `bootstrap/install-base.sh` — Phase 1: system foundations
+- `bootstrap/install-user.sh` — Phase 2: user dotfiles
+- `bootstrap/install-devbox.sh` — Phase 3: developer tools
+- `dotfiles/base/.zshrc` — Base shell config (135 lines)
+- `dotfiles/base/.gitconfig` — Base git config (no [user])
+- `dotfiles/base/.aliases` — Shell aliases with modern tool replacements
+- `dotfiles/devbox/50-devbox.zsh` — Dev aliases drop-in
+- `brewfiles/Brewfile.base` — Core Homebrew packages
+- `brewfiles/Brewfile.devbox` — Dev Homebrew packages
+- `globals/globals.base.sh` — nvm, pyenv, Claude Code installer
+- `globals/globals.devbox.sh` — npm/pip global packages
+- `macos/defaults-base.sh` — Universal macOS preferences
+- `macos/display-watch.sh` — Hardware detection daemon
+- `claude/statusline.sh` — Claude Code status line formatter
+- `iterm2/generate-profile.py` — iTerm2 dynamic profile generator
+- `test/validate.sh` — 10-check validation suite
+- `docs/architecture/README.md` — Ecosystem architecture (C4 diagrams)
+
+### dotfiles-private
+- `dotfiles/orgs/{org}/.gitconfig` — Per-org git identity
+- `dotfiles/orgs/{org}/.zshrc` — Per-org shell config
+- `globals/orgs/globals.{org}.sh` — Per-org env vars (op:// secrets)
+- `brewfiles/orgs/Brewfile.{org}` — Per-org Homebrew packages
+- `claude/orgs/{org}/CLAUDE.md` — Per-org Claude instructions
+- `claude/orgs/{org}/mcp-{org}.json` — Per-org MCP config
+- `claude/providers/*.sh` — API key provider scripts
+- `devbox/presets/*.json` — Per-project devbox presets
+- `canvas/orgs/{org}/CLAUDE.md.tmpl` — Per-org canvas session templates
+
+### devbox
+- `src/devbox/cli.py` — Click CLI entry
+- `src/devbox/core.py` — Core orchestration (create/nuke/list/rebuild)
+- `src/devbox/registry.py` — ~/.devbox/registry.json CRUD
+- `src/devbox/presets.py` — Preset loading + Pydantic validation
+- `src/devbox/macos.py` — dscl user management
+- `src/devbox/ssh.py` — SSH key generation
+- `src/devbox/github.py` — GitHub API (SSH key lifecycle)
+- `src/devbox/iterm2.py` — iTerm2 dynamic profile management
+- `src/devbox/bootstrap.py` — nvm/pyenv/brew/npm/pip setup
+- `src/devbox/auth.py` — Anthropic/AWS credential injection
+- `src/devbox/health.py` — Heartbeat + atrophy detection
+- `docs/architecture/README.md` — Architecture documentation
+
+### canvas
+- `canvas/cli.py` — Click CLI commands
+- `canvas/core.py` — Core orchestration (new_session, list, archive, etc.)
+- `canvas/registry.py` — Registry CRUD
+- `canvas/models.py` — Session dataclass + enums
+- `canvas/slug.py` — Slug generation + validation
+- `canvas/template.py` — Jinja2 template rendering
+- `canvas/config.py` — Path resolution + config loading
+- `docs/architecture/README.md` — Architecture documentation

--- a/.claude/agents/dotfiles-expert/knowledge/secrets-and-security.md
+++ b/.claude/agents/dotfiles-expert/knowledge/secrets-and-security.md
@@ -18,10 +18,10 @@ export SECRET="$(op read "op://VaultName/ItemName/field")"
 
 | Tool | Secret Type | Example op:// Path |
 |---|---|---|
-| dotfiles-private globals | GitHub tokens, AWS credentials | `op://Personal/GitHub Token/credential` |
-| dotfiles-private providers | Anthropic API keys | `op://Personal/Anthropic API Key/credential` |
-| dotfiles-private providers | AWS Bedrock credentials | `op://Splash/AWS Bedrock/access_key_id` |
-| loadout init | GitHub token for SSH key registration | `op://Personal/GitHub Token/credential` |
+| dotfiles-private globals | GitHub tokens, AWS credentials | `op://{vault}/GitHub Token/credential` |
+| dotfiles-private providers | Anthropic API keys | `op://{vault}/Anthropic API Key/credential` |
+| dotfiles-private providers | AWS Bedrock credentials | `op://{vault}/AWS Bedrock/access_key_id` |
+| loadout init | GitHub token for SSH key registration | `op://{vault}/GitHub Token/credential` |
 | devbox create | Preset env vars (any op:// refs resolved at create time) | varies per preset |
 
 ### SSH Agent

--- a/.claude/agents/dotfiles-expert/knowledge/secrets-and-security.md
+++ b/.claude/agents/dotfiles-expert/knowledge/secrets-and-security.md
@@ -1,0 +1,70 @@
+---
+name: secrets-and-security
+description: 1Password integration, secret patterns, security validation across the ecosystem
+---
+
+# Secrets & Security
+
+## 1Password CLI (op)
+
+All secrets across the ecosystem use 1Password CLI references — never hardcoded values.
+
+### Pattern
+```bash
+export SECRET="$(op read "op://VaultName/ItemName/field")"
+```
+
+### Usage by Tool
+
+| Tool | Secret Type | Example op:// Path |
+|---|---|---|
+| dotfiles-private globals | GitHub tokens, AWS credentials | `op://Personal/GitHub Token/credential` |
+| dotfiles-private providers | Anthropic API keys | `op://Personal/Anthropic API Key/credential` |
+| dotfiles-private providers | AWS Bedrock credentials | `op://Splash/AWS Bedrock/access_key_id` |
+| loadout init | GitHub token for SSH key registration | `op://Personal/GitHub Token/credential` |
+| devbox create | Preset env vars (any op:// refs resolved at create time) | varies per preset |
+
+### SSH Agent
+SSH keys are managed by 1Password SSH agent — no plaintext private keys on disk.
+
+## Devbox Security
+
+- Secrets resolved from presets at create time, written to `/Users/dx-{name}/.devbox-env` (mode 0600)
+- Sudoers drop-in: only allows `dscl` and `createhomedir` on `dx-*` users
+- UID range 600-699 for devbox accounts
+- SSH key pair generated fresh per devbox; public key registered with GitHub, removed on nuke
+- Inbound SSH: parent user's GitHub `.keys` endpoint used for authorized_keys
+- Password disabled on devbox accounts (SSH-only access)
+
+## Canvas Security
+
+- Path traversal protection: validates org/slug against `/\\..[\x00]` regex
+- Templates are user-controlled local files (Jinja2 unsandboxed — safe because local)
+- TOCTOU on slug collision acknowledged as acceptable for single-user CLI
+
+## Validation Suite (dotfiles repo)
+
+`test/validate.sh` runs 10 checks including:
+
+**Secrets scan** — regex patterns for common secret formats:
+- OpenAI API keys
+- GitHub tokens (`ghp_`, `gho_`, `ghu_`)
+- AWS access keys (`AKIA`)
+- Slack tokens (`xoxb-`, `xoxp-`)
+- Private key headers (`BEGIN.*PRIVATE KEY`)
+
+**Hardcoded path scan** — flags `/Users/` or `/home/` patterns for portability.
+
+## Licensing
+
+All repos use **AGPL-3.0-or-later** (strong copyleft).
+
+AI attribution policy: No "Co-Authored-By" or AI attribution in commits (copyright protection for AGPL-3.0). This is enforced in CI for canvas and devbox.
+
+## Public Repo Rules (dotfiles)
+
+Never commit to the public dotfiles repo:
+- API keys, tokens, or secrets
+- Personal email addresses or identifiers
+- Machine-specific paths (`/Users/username/`)
+- Organization-specific configurations

--- a/.claude/agents/dotfiles-expert/knowledge/state-locations.md
+++ b/.claude/agents/dotfiles-expert/knowledge/state-locations.md
@@ -1,0 +1,76 @@
+---
+name: state-locations
+description: Where each tool stores config, state, and runtime data on the filesystem
+---
+
+# State & Storage Locations
+
+## Config Repositories (Git-managed)
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.dotfiles/` | loadout (clones it) | Public base config repo |
+| `~/.dotfiles-private/` | loadout (clones it) | Private org config repo |
+
+## Build Output
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.dotfiles/build/` | loadout build | Staged merged output before install to ~/ |
+| `~/.dotfiles/backups/` | loadout build | Pre-overwrite backups (`{file}.{YYYYMMDDTHHMMSSZ}`) |
+
+## Tool State
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.dotfiles/.loadout.toml` | loadout | Config: user, orgs, versions, GitHub token op path |
+| `~/.loadout/` | dotfiles bootstrap | Runtime: `logs/`, `backups/`, `last-fetch` timestamp |
+| `~/.devbox/config.json` | devbox | Global config: `parent_github_user` |
+| `~/.devbox/registry.json` | devbox | Devbox index: version, devboxes[], status lifecycle |
+| `~/.canvas/config` | canvas / loadout | Active org selector (JSON with `org` field) |
+| `~/.canvas/registry.json` | canvas | Session index: active/archived sessions |
+| `~/.canvas/sessions/{slug}/` | canvas | Per-session dirs with rendered CLAUDE.md |
+
+## Shell & Git Config (installed to ~/)
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.zshrc` | loadout build | Merged shell config |
+| `~/.aliases` | loadout build | Merged shell aliases |
+| `~/.gitconfig` | loadout build | Merged git config (no [user] section) |
+| `~/.gitconfig.local` | user (manual) | Personal git identity |
+| `~/.gitconfig.d/` | loadout build | Per-org git configs via [include] |
+| `~/.zshrc.d/` | loadout build + globals | Numeric-sorted shell drop-ins |
+| `~/.zshrc.local` | user (manual) | Final private shell overrides |
+
+## Claude Code Config
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.claude/mcp.json` | loadout claude | Deep-merged MCP server config |
+| `~/.claude/CLAUDE.md` | loadout claude | Concatenated org context |
+| `~/.claude/providers/` | loadout claude | API key provider scripts (chmod 755) |
+| `~/.claude/statusline.sh` | loadout claude | Custom status line formatter |
+
+## Runtime Managers
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/.nvm/` | nvm (installed by globals) | Node.js version manager |
+| `~/.pyenv/` or Homebrew-managed | pyenv | Python version manager |
+
+## macOS System
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `~/Library/LaunchAgents/com.oakensoul.display-defaults.plist` | loadout init | Display-watch daemon |
+| `~/.loadout/logs/display-watch.log` | display-watch.sh | Daemon log |
+| `/etc/sudoers.d/devbox` | devbox (sudo) | Restrictive NOPASSWD for dx-* user management |
+
+## Devbox User Accounts
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `/Users/dx-{name}/` | devbox create | Devbox user home directory |
+| `/Users/dx-{name}/.devbox-env` | devbox create | Resolved secrets (mode 0600) |
+| `/Users/dx-{name}/.devbox_heartbeat` | devbox zshrc hook | Last-login timestamp for atrophy detection |

--- a/.claude/agents/dotfiles-expert/knowledge/state-locations.md
+++ b/.claude/agents/dotfiles-expert/knowledge/state-locations.md
@@ -39,7 +39,7 @@ description: Where each tool stores config, state, and runtime data on the files
 | `~/.aliases` | loadout build | Merged shell aliases |
 | `~/.gitconfig` | loadout build | Merged git config (no [user] section) |
 | `~/.gitconfig.local` | user (manual) | Personal git identity |
-| `~/.gitconfig.d/` | loadout build | Per-org git configs via [include] |
+| `~/.gitconfig.d/org.gitconfig` | loadout build | Single merged org git config (included by .gitconfig) |
 | `~/.zshrc.d/` | loadout build + globals | Numeric-sorted shell drop-ins |
 | `~/.zshrc.local` | user (manual) | Final private shell overrides |
 


### PR DESCRIPTION
## Summary
- Adds a `dotfiles-expert` Claude Code subagent with 8 knowledge documents covering the Loadout ecosystem
- Topics: architecture overview, merge strategies, repo locations, bootstrap lifecycle, multi-org model, secrets/security, state locations
- Enables Claude Code to answer detailed questions about the 5-repo Loadout system without needing to explore the codebase each time

## Test plan
- [ ] Verify agent loads correctly via `@dotfiles-expert` in Claude Code
- [ ] Confirm knowledge docs are accurate against current repo state